### PR TITLE
Get rid of dependency for store in HeatmapWizardMultiSample

### DIFF
--- a/src/components/heatmap/HeatmapWizardMultiSample.vue
+++ b/src/components/heatmap/HeatmapWizardMultiSample.vue
@@ -73,6 +73,8 @@ export default class HeatmapWizardMultiSample extends Vue {
     private dataset: Assay;
     @Prop()
     private searchSettings: MPAConfig;
+    @Prop({ required: true })
+    private selectedDatasets: Assay[];
 
     private clusterRows: boolean = true;
     private clusterColumns: boolean = true;
@@ -192,7 +194,12 @@ export default class HeatmapWizardMultiSample extends Vue {
     }
 
     private async computeHeatmapAndProceed() {
-        let newHash = sha256(this.normalizer + this.dataSource + this.selectedItems.toString()).toString();
+        let newHash = sha256(
+            this.normalizer +
+            this.dataSource +
+            this.selectedItems.toString() + 
+            this.selectedDatasets.map(el => el.getName()).toString()
+        ).toString();
 
         if (newHash === this.previouslyComputed) {
             return;
@@ -213,14 +220,14 @@ export default class HeatmapWizardMultiSample extends Vue {
             rows.push({ id: i.toString(), name: item.name });
         }
 
-        for (let i = 0; i < this.$store.getters.selectedDatasets.length; i++) {
-            let item: Assay = this.$store.getters.selectedDatasets[i];
+        for (let i = 0; i < this.selectedDatasets.length; i++) {
+            let item: Assay = this.selectedDatasets[i];
             cols.push({ id: i.toString(), name: item.getName() });
         }
 
         for (let item of this.selectedItems) {
             let gridRow: number[] = [];
-            for (let container of this.$store.getters.selectedDatasets) {
+            for (let container of this.selectedDatasets) {
                 let value: number = (await item.getAffectedPeptides(container.dataRepository)).length;
                 gridRow.push(value);
             }


### PR DESCRIPTION
The HeatmapWizardMultiSample-component retrieved all selected datasets directly from the Vuex-store. In order to get rid of the dependency on the store by this component, the selected datasets now need to be passed as a prop.