### PR TITLE
Fix/pride dataset not added

### DIFF
--- a/src/components/dataset/LoadPrideDatasetCard.vue
+++ b/src/components/dataset/LoadPrideDatasetCard.vue
@@ -37,6 +37,7 @@ import DatasetMixin from "./DatasetMixin.vue";
 import DatasetManager from "../../logic/data-management/DatasetManager";
 import DatasetForm from "./DatasetForm.vue";
 import Snackbar from "../custom/Snackbar.vue";
+import Assay from "../../logic/data-management/assay/Assay";
 
 @Component({
     components: {
@@ -79,7 +80,8 @@ export default class LoadPrideDatasetCard extends mixins(DatasetMixin) {
 
     private selectPrideAssay() {
         if (this.$refs.prideDatasetForm.isValid()) {
-            this.storeDataset(this.pridePeptides, this.prideName, this.prideSave);
+            const createdAssay: Assay = this.storeDataset(this.pridePeptides, this.prideName, this.prideSave);
+            this.$emit("create-assay", createdAssay);
         }
     }
 }

--- a/src/components/dataset/LoadPrideDatasetCard.vue
+++ b/src/components/dataset/LoadPrideDatasetCard.vue
@@ -9,7 +9,7 @@ after which the required information is downloaded and transformed into an Assay
             <h3>Load data from the PRIDE archive</h3>
             <p>You can easily load data from the <a href="http://www.ebi.ac.uk/pride/" target="_blank">PRIDE</a> data repository. Simply enter an assay id (e.g. 8500) in the field below and click the 'Load PRIDE Dataset' button. The corresponding dataset will then be fetched using the PRIDE API and loaded into the search form on the left.</p>
             <v-form ref="prideAssayForm" @submit.prevent>
-                <v-text-field label="Assay id" placeholder="e.g. 8500" :disabled="prideLoading" v-model="prideAssay" :rules="[value => !!value || 'Please enter a valid PRIDE assay number']" clearable></v-text-field>
+                <v-text-field v-on:keyup.enter="fetchPrideAssay()" label="Assay id" placeholder="e.g. 8500" :disabled="prideLoading" v-model="prideAssay" :rules="[value => !!value || 'Please enter a valid PRIDE assay number']" clearable></v-text-field>
             </v-form>
             <div class="card-actions">
                 <v-btn v-if="!prideLoading" @click="fetchPrideAssay()">
@@ -60,7 +60,7 @@ export default class LoadPrideDatasetCard extends mixins(DatasetMixin) {
     private prideProgress: number = 0;
 
     private fetchPrideAssay(): void {
-        if (this.$refs.prideAssayForm.validate()) {
+        if (!this.prideLoading && this.$refs.prideAssayForm.validate()) {
             this.prideLoading = true;
             let datasetManager: DatasetManager = new DatasetManager();
             let prideNumber: number = parseInt(this.prideAssay);


### PR DESCRIPTION
This PR fixes the issue https://github.com/unipept/unipept/issues/912. Pressing "enter" is now also considered as a trigger for fetching pride datasets.