### PR TITLE
Update to new Canvg API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4122,6 +4122,11 @@
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
       "dev": true
     },
+    "@types/raf": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.0.tgz",
+      "integrity": "sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw=="
+    },
     "@types/sanitize-html": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-1.20.2.tgz",
@@ -8806,12 +8811,31 @@
       "dev": true
     },
     "canvg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/canvg/-/canvg-2.0.0.tgz",
-      "integrity": "sha512-PiKa+sjzzAv8HONsBaJZRhZ3eCM5uJkpFgF0rSzcamOrdXdls81ukjNxtz7JYyxucj6WpIkZwk9j7Jku0+ivqQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.5.tgz",
+      "integrity": "sha512-oIfE6EUhIxR6+jC76sAATLbcKtwYZTfdU6AEUpWOJfzL02Oh4fTnsdfph3fE5KPM9v2bCK8mcPsFoq0IGOV79g==",
       "requires": {
+        "@babel/runtime": "^7.6.3",
+        "@types/raf": "^3.4.0",
+        "core-js": "3",
+        "raf": "^3.4.1",
         "rgbcolor": "^1.0.1",
         "stackblur-canvas": "^2.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
+          "integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "core-js": {
+          "version": "3.6.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+        }
       }
     },
     "capture-exit": {
@@ -21529,6 +21553,14 @@
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
       "dev": true
     },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
@@ -23453,8 +23485,7 @@
     "regenerator-runtime": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
-      "dev": true
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
     },
     "regenerator-transform": {
       "version": "0.14.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "babel-polyfill": "^6.26.0",
-    "canvg": "^2.0.0",
+    "canvg": "^3.0.5",
     "clipboard-polyfill": "^2.8.6",
     "convert-svg-to-png": "^0.5.0",
     "crypto-js": "^3.1.9-1",

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -317,53 +317,6 @@ export function numberToPercent(number, digits = 0) {
 }
 
 /**
- * Use canvg to convert an inline svg element to a PNG DataURL
- * @param {string} svgSelector The DOM selector of the SVG or jQuery object
- * @returns {string} A dataURL containing the resulting PNG
-*/
-export async function svg2pngDataURL(svgSelector: string) : Promise<string> { 
-    var canvg = require("canvg");
-    var el = $(svgSelector).get(0);
-
-    var canvas = document.createElement("canvas");
-
-    // automatically size canvas to svg element and render
-    canvg(canvas, el.outerHTML);
-
-    // double size of canvas
-    canvas.setAttribute("height", canvas.height * 2 + "px")
-    canvas.setAttribute("width", canvas.width * 2 + "px")
-    // render svg element to this resized canvas (doubled resolution)
-    canvg(canvas, el.outerHTML, { ignoreDimensions: true, scaleWidth: canvas.width, scaleHeight: canvas.height });
-
-    return canvas.toDataURL();
-}
-
-export function svg2svgDataURL(svgSelector: string) {
-    var el = $(svgSelector).get(0);
-    var svgString = new XMLSerializer().serializeToString(el);
-    var decoded = unescape(encodeURIComponent(svgString));
-    // convert the svg to base64
-    var base64 = btoa(decoded);
-    return `data:image/svg+xml;base64,${base64}`;
-}
-
-/**
- * Uses html2canvas to convert canvas to a PNG.
- *
- * @param {string} selector The DOM selector
- * @returns {string} A dataURL containing the resulting PNG
-*/
-export async function dom2pngDataURL(selector: string) : Promise<string> {
-    const html2canvas = require("html2canvas");
-    // Use html2canvas to convert selected element to canvas, 
-    // then convert that canvas to a dataURL
-    let element = $(selector).get(0);
-    return html2canvas(element, { scale: 2 })
-        .then((canvasElement) => canvasElement.toDataURL())
-}
-
-/**
  * Posts data to a url as JSON and returns a promise containing the parsed
  * (JSON) response
  *


### PR DESCRIPTION
The API of Canvg changed from version 2.0 to version 3.0, breaking Unipept's ability to download image versions of the visualizations. This PR updates the Canvg API used.