### PR TITLE
Add ability to specify download-format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unipept-web-components",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/analysis/statistics/ExperimentSummaryCard.vue
+++ b/src/components/analysis/statistics/ExperimentSummaryCard.vue
@@ -31,7 +31,7 @@ change the currently active search settings and redo the analysis of all selecte
                     </v-btn>
                 </tooltip>
                 <tooltip message="Download a CSV-file with the results of this analysis.">
-                        <v-menu offset-y>
+                        <v-menu offset-y bottom left origin="top right">
                             <template v-slot:activator="{ on }">
                                 <v-btn min-width="187" :disabled="disabled || exportLoading" v-on="on" color="default">
                                     <div v-if="!exportLoading">
@@ -39,6 +39,7 @@ change the currently active search settings and redo the analysis of all selecte
                                             mdi-download
                                         </v-icon>
                                         Download results
+                                        <v-icon>mdi-menu-down</v-icon>
                                     </div>
                                     <v-progress-circular v-else indeterminate color="black" :size="20">
                                     </v-progress-circular>

--- a/src/components/analysis/statistics/ExperimentSummaryCard.vue
+++ b/src/components/analysis/statistics/ExperimentSummaryCard.vue
@@ -1,5 +1,5 @@
 <docs>
-The ExperimentSummaryCard summarizes an experiment into statistics: mainly the amount of peptides that were found, the 
+The ExperimentSummaryCard summarizes an experiment into statistics: mainly the amount of peptides that were found, the
 peptides that were not found (including the ability to show these as a list). This component also allows the user to
 change the currently active search settings and redo the analysis of all selected assays.
 </docs>
@@ -31,16 +31,29 @@ change the currently active search settings and redo the analysis of all selecte
                     </v-btn>
                 </tooltip>
                 <tooltip message="Download a CSV-file with the results of this analysis.">
-                    <v-btn min-width="187" :disabled="disabled || exportLoading" @click="downloadCsv()" color="default">
-                        <div v-if="!exportLoading">
-                            <v-icon>
-                                mdi-download
-                            </v-icon>
-                            Download results
-                        </div>
-                        <v-progress-circular v-else indeterminate color="black" :size="20">
-                        </v-progress-circular>
-                    </v-btn>
+                        <v-menu offset-y>
+                            <template v-slot:activator="{ on }">
+                                <v-btn min-width="187" :disabled="disabled || exportLoading" v-on="on" color="default">
+                                    <div v-if="!exportLoading">
+                                        <v-icon>
+                                            mdi-download
+                                        </v-icon>
+                                        Download results
+                                    </div>
+                                    <v-progress-circular v-else indeterminate color="black" :size="20">
+                                    </v-progress-circular>
+                                </v-btn>
+                            </template>
+                            <v-list>
+                                <v-list-item @click="downloadCsv()">
+                                    <v-list-item-title>Comma-separated (international)</v-list-item-title>
+                                </v-list-item>
+                                <v-list-item @click="downloadCsv(';', ',')">
+                                    <v-list-item-title>Semi-colon-separated (Europe)</v-list-item-title>
+                                </v-list-item>
+                            </v-list>
+                        </v-menu>
+
                 </tooltip>
             </div>
             <v-divider></v-divider>
@@ -170,12 +183,14 @@ export default class ExperimentSummaryCard extends Vue {
         }
     }
 
-    private async downloadCsv(): Promise<void> {
+    private async downloadCsv(separator: string = ",", functionalSeparator: string = ";"): Promise<void> {
         if (this.activeAssay) {
             this.exportLoading = true;
             const exportMng: ExportManager = new ExportManager();
             const csv: string = await exportMng.exportResultsAsCsv(
-                this.activeAssay.dataRepository as MetaProteomicsDataRepository
+                this.activeAssay.dataRepository as MetaProteomicsDataRepository,
+                separator,
+                functionalSeparator
             );
 
             await downloadDataByForm(csv, "mpa_result.csv", "text/csv");

--- a/src/logic/data-source/ExportManager.ts
+++ b/src/logic/data-source/ExportManager.ts
@@ -9,35 +9,37 @@ import { PeptideData } from "../api/pept2data/Response";
 
 export default class ExportManager {
     // TODO this code should be cleaned up, once all the proteincounts are part of the data sources.
-    public async exportResultsAsCsv(repo: MetaProteomicsDataRepository): Promise<string> {
+    public async exportResultsAsCsv(
+        repo: MetaProteomicsDataRepository,
+        separator: string = ",",
+        goSeparator: string = ";"
+    ): Promise<string> {
         const taxaSource = await repo.createTaxaDataSource();
         const taxos: TaxonomicsSummary[] = await taxaSource.getTaxonomicSummaries();
 
-        const ecSource = await repo.createEcDataSource();
         const goSource = await repo.createGoDataSource();
 
         // These need to be manually specified here to retain a specific order!
         const goNameSpaces: GoNameSpace[] = [
             GoNameSpace.BiologicalProcess,
-            GoNameSpace.CellularComponent, 
+            GoNameSpace.CellularComponent,
             GoNameSpace.MolecularFunction
         ];
 
-        let result: string = 
-            "peptide,lca," + Object.values(TaxumRank).join(",") + "," + "EC," + 
-            goNameSpaces.map(ns => `GO (${ns})`).join(",") + "\n";
+        let result: string =
+            `peptide${separator}lca${separator}${Object.values(TaxumRank).join(separator)}${separator}EC${separator}${goNameSpaces.map(ns => `GO (${ns})`).join(separator)}\n`;
 
         const processedContainer: ProcessedPeptideContainer = await repo.initProcessedPeptideContainer();
 
         for (const tax of taxos) {
             // Process taxonomic information
-            let row = tax.sequence + "," + tax.lcaName + "," + tax.lineageNames.map(e => {
+            let row = tax.sequence + separator + tax.lcaName + separator + tax.lineageNames.map(e => {
                 if (e === null) {
                     return "";
                 } else {
                     return e;
                 }
-            }).join(",");
+            }).join(separator);
 
 
             const peptData: PeptideData = processedContainer.response.get(tax.sequence);
@@ -52,20 +54,20 @@ export default class ExportManager {
 
             const ecNumbers = dataList.filter(x => x.code.startsWith("EC:")).sort((a, b) => b.count - a.count);
 
-            row += ",";
+            row += separator;
             row += ecNumbers
                 .slice(0, 3)
                 .map(a => `${a.code.substr(3)} (${this.numberToPercent(a.count / peptData.fa.counts.EC)})`)
-                .join(";");
-            row += ",";
+                .join(goSeparator);
+            row += separator;
 
             row += (await Promise.all(goNameSpaces.map(async ns => {
                 const goTerms = (await goSource.getGoTerms(ns, 0, [tax.sequence])).map(x => {
                     return dataList.find(y => y.code === x.code);
                 }).sort((a, b) => b.count - a.count);
 
-                return goTerms.slice(0, 3).map(a => `${a.code} (${this.numberToPercent(a.count / peptData.fa.counts.GO)})`).join(";");
-            }))).join(",");
+                return goTerms.slice(0, 3).map(a => `${a.code} (${this.numberToPercent(a.count / peptData.fa.counts.GO)})`).join(goSeparator);
+            }))).join(separator);
 
             row += "\n";
             // Duplicate row in the case the peptide was more present more than once.


### PR DESCRIPTION
Improve the "export functionality" with the ability for users to chose which type of CSV they want to download (international or semi-colon based).

The "export"-button is now a dropdown menu with the following content:

![image](https://user-images.githubusercontent.com/9608686/77819667-e7112d00-70dc-11ea-9474-9f8b5bf0091d.png)

See: https://github.com/unipept/unipept/issues/975
