### PR TITLE
feature/single peptide fa

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleNameMapper": {
       "^@/(.*)$": "<rootDir>/src/$1",
-      "^worker-loader!./Pept2Data.worker.js$": "<rootDir>/src/test/MockPeptideContainerProcessor"
+      "^worker-loader!./Pept2Data.worker.js$": "<rootDir>/src/test/MockPeptideContainerProcessor",
+      "html-to-image-no-fonts": "<rootDir>/src/test/mocks/HtmlToImage"
     },
     "testEnvironment": "jsdom",
     "setupFilesAfterEnv": [

--- a/src/business/communication/NetworkUtils.ts
+++ b/src/business/communication/NetworkUtils.ts
@@ -10,14 +10,15 @@ export default class NetworkUtils {
      * @return A promise containing the parsed response data.
      */
     public static async postJSON(url, data): Promise<any> {
-        return fetch(url, {
+        const response = await fetch(url, {
             method: "POST",
             headers: {
                 "Accept": "application/json",
                 "Content-Type": "application/json",
             },
-            body: data,
-        }).then(res => res.json());
+            body: data
+        });
+        return response.json();
     }
 
     /**

--- a/src/business/processors/CountTableProcessor.ts
+++ b/src/business/processors/CountTableProcessor.ts
@@ -1,0 +1,5 @@
+import { CountTable } from "./../counts/CountTable";
+
+export default interface CountTableProcessor<OntologyId> {
+    getCountTable(): Promise<CountTable<OntologyId>>;
+}

--- a/src/business/processors/ProteomicsCountTableProcessor.ts
+++ b/src/business/processors/ProteomicsCountTableProcessor.ts
@@ -1,7 +1,7 @@
 import { CountTable } from "./../counts/CountTable";
 import { Peptide } from "./../ontology/raw/Peptide";
+import CountTableProcessor from "./CountTableProcessor";
 
-export default interface ProteomicsCountTableProcessor<OntologyId> {
-    getCountTable(): Promise<CountTable<OntologyId>>;
+export default interface ProteomicsCountTableProcessor<OntologyId> extends CountTableProcessor<OntologyId> {
     getAnnotationPeptideMapping(): Promise<Map<OntologyId, Peptide[]>>;
 }

--- a/src/business/processors/functional/FunctionalCountTableProcessor.ts
+++ b/src/business/processors/functional/FunctionalCountTableProcessor.ts
@@ -131,8 +131,6 @@ export default abstract class FunctionalCountTableProcessor<
             tablePerNamespace.set(ns, new Map<OntologyId, number>());
         }
 
-        const generalCounts = new Map<OntologyId, number>();
-
         // Add each definition to the count table of it's specific namespace.
         for (const [term, counts] of countsPerCode) {
             const definition: DefinitionType = ontology.getDefinition(term);
@@ -140,7 +138,6 @@ export default abstract class FunctionalCountTableProcessor<
             if (definition) {
                 const nsMap = tablePerNamespace.get(definition.namespace);
                 nsMap.set(term, counts);
-                generalCounts.set(term, counts);
             }
         }
 
@@ -148,7 +145,7 @@ export default abstract class FunctionalCountTableProcessor<
         for (const [ns, table] of tablePerNamespace) {
             this.countTables.set(ns, new CountTable<OntologyId>(table));
         }
-        this.generalCountTable = new CountTable<OntologyId>(generalCounts);
+        this.generalCountTable = new CountTable<OntologyId>(countsPerCode);
 
         this.trust = new FunctionalTrust(annotatedCount, this.peptideCountTable.totalCount);
     }

--- a/src/business/processors/functional/FunctionalProteinCountTableProcessor.ts
+++ b/src/business/processors/functional/FunctionalProteinCountTableProcessor.ts
@@ -49,11 +49,10 @@ export default abstract class FunctionalProteinCountTableProcessor<
         const items = proteins.reduce((acc, p) => {
             const annotations = this.getAnnotationsFromProtein(p);
             if (annotations && annotations.length > 0) {
-                acc.push(...annotations);
-                return acc;
-            } else {
                 annotatedCount++;
+                acc.push(...annotations);
             }
+            return acc;
         }, []);
 
         const countsPerCode = new Map<OntologyId, number>();

--- a/src/business/processors/functional/FunctionalProteinCountTableProcessor.ts
+++ b/src/business/processors/functional/FunctionalProteinCountTableProcessor.ts
@@ -16,9 +16,10 @@ export default abstract class FunctionalProteinCountTableProcessor<
     private generalCountTable: CountTable<OntologyId>;
     private trust: FunctionalTrust;
 
-    public constructor(
+    protected constructor(
         public readonly peptide: Peptide,
-        public readonly equateIl: boolean
+        public readonly equateIl: boolean,
+        protected readonly itemPrefix: string = ""
     ) {}
 
     public async getCountTable(namespace?: FunctionalNamespace): Promise<CountTable<OntologyId>> {
@@ -50,7 +51,7 @@ export default abstract class FunctionalProteinCountTableProcessor<
             const annotations = this.getAnnotationsFromProtein(p);
             if (annotations && annotations.length > 0) {
                 annotatedCount++;
-                acc.push(...annotations);
+                acc.push(...annotations.map(e => this.itemPrefix + e));
             }
             return acc;
         }, []);

--- a/src/business/processors/functional/FunctionalProteinCountTableProcessor.ts
+++ b/src/business/processors/functional/FunctionalProteinCountTableProcessor.ts
@@ -1,0 +1,95 @@
+import FunctionalDefinition from "./../../ontology/functional/FunctionalDefinition";
+import CountTableProcessor from "../CountTableProcessor";
+import { FunctionalNamespace } from "./../../ontology/functional/FunctionalNamespace";
+import { CountTable } from "./../../counts/CountTable";
+import FunctionalTrust from "./FunctionalTrust";
+import { Peptide } from "./../../ontology/raw/Peptide";
+import ProteinProcessor from "./../protein/ProteinProcessor";
+import ProteinDefinition from "./../../ontology/protein/ProteinDefinition";
+import { Ontology } from "./../../ontology/Ontology";
+
+export default abstract class FunctionalProteinCountTableProcessor<
+    OntologyId,
+    DefinitionType extends FunctionalDefinition
+> implements CountTableProcessor<OntologyId> {
+    private countTables: Map<FunctionalNamespace, CountTable<OntologyId>> = new Map();
+    private generalCountTable: CountTable<OntologyId>;
+    private trust: FunctionalTrust;
+
+    public constructor(
+        public readonly peptide: Peptide,
+        public readonly equateIl: boolean
+    ) {}
+
+    public async getCountTable(namespace?: FunctionalNamespace): Promise<CountTable<OntologyId>> {
+        await this.compute();
+        if (namespace) {
+            return this.countTables.get(namespace);
+        } else {
+            return this.generalCountTable;
+        }
+    }
+
+    public async getTrust(): Promise<FunctionalTrust> {
+        await this.compute();
+        return this.trust;
+    }
+
+    private async compute(): Promise<void> {
+        if (this.countTables.size > 0) {
+            return;
+        }
+
+        const proteinProcessor = new ProteinProcessor();
+        const proteins = await proteinProcessor.getProteinsByPeptide(this.peptide, this.equateIl);
+
+        // How many proteins are annotated with at least one item?
+        let annotatedCount: number = 0;
+
+        const items = proteins.reduce((acc, p) => {
+            const annotations = this.getAnnotationsFromProtein(p);
+            if (annotations && annotations.length > 0) {
+                acc.push(...annotations);
+                return acc;
+            } else {
+                annotatedCount++;
+            }
+        }, []);
+
+        const countsPerCode = new Map<OntologyId, number>();
+        for (const item of items) {
+            countsPerCode.set(item, (countsPerCode.get(item) || 0) + 1);
+        }
+
+        this.generalCountTable = new CountTable<OntologyId>(countsPerCode);
+        this.trust = new FunctionalTrust(annotatedCount, proteins.length);
+
+        const ontology = await this.getOntology(this.generalCountTable);
+
+        // Split all the counts per namespace.
+        const tablePerNamespace = new Map<FunctionalNamespace, Map<OntologyId, number>>();
+
+        for (const ns of this.getNamespaces()) {
+            tablePerNamespace.set(ns, new Map<OntologyId, number>());
+        }
+
+        for (const [term, counts] of countsPerCode) {
+            const definition = ontology.getDefinition(term);
+
+            if (definition) {
+                const nsMap = tablePerNamespace.get(definition.namespace);
+                nsMap.set(term, counts);
+            }
+        }
+
+        for (const [ns, table] of tablePerNamespace) {
+            this.countTables.set(ns, new CountTable<OntologyId>(table));
+        }
+    }
+
+    protected async abstract getOntology(countTable: CountTable<OntologyId>): Promise<Ontology<OntologyId, DefinitionType>>;
+
+    protected abstract getAnnotationsFromProtein(p: ProteinDefinition): OntologyId[];
+
+    protected abstract getNamespaces(): FunctionalNamespace[];
+}

--- a/src/business/processors/functional/FunctionalTrust.ts
+++ b/src/business/processors/functional/FunctionalTrust.ts
@@ -6,12 +6,12 @@
  */
 export default class FunctionalTrust {
     /**
-     * @param annotatedPeptides How many of the peptides that were looked up are, in-fact, associated with at least one
-     * of the items in the resulting count table?
-     * @param totalAmountOfPeptides How many peptides were looked up in total?
+     * @param annotatedItems How many of the items (e.g. peptides) that were looked up are, in-fact, associated with
+     * at least one of the items in the resulting count table?
+     * @param totalAmountOfItems How many items were looked up in total?
      */
     constructor(
-        public readonly annotatedPeptides,
-        public readonly totalAmountOfPeptides,
+        public readonly annotatedItems,
+        public readonly totalAmountOfItems,
     ) {}
 }

--- a/src/business/processors/functional/__tests__/FunctionalCountTableProcessor.spec.ts
+++ b/src/business/processors/functional/__tests__/FunctionalCountTableProcessor.spec.ts
@@ -42,15 +42,15 @@ describe("FunctionalCountTableProcessor", () => {
 
         let trust = await ecCountProcessor.getTrust();
         // Only 3 out of the 4 peptides are annotated with at least one EC-number.
-        expect(trust.annotatedPeptides).toBe(3);
+        expect(trust.annotatedItems).toBe(3);
         // We did look up 4 peptides
-        expect(trust.totalAmountOfPeptides).toBe(4);
+        expect(trust.totalAmountOfItems).toBe(4);
 
         ecCountProcessor = new EcCountTableProcessor(multiCountTable, new SearchConfiguration(true, false, false), 0);
 
         trust = await ecCountProcessor.getTrust();
-        expect(trust.annotatedPeptides).toBe(6);
-        expect(trust.totalAmountOfPeptides).toBe(7);
+        expect(trust.annotatedItems).toBe(6);
+        expect(trust.totalAmountOfItems).toBe(7);
 
         done();
     });

--- a/src/business/processors/functional/__tests__/FunctionalProteinCountTableProcessor.spec.ts
+++ b/src/business/processors/functional/__tests__/FunctionalProteinCountTableProcessor.spec.ts
@@ -1,0 +1,38 @@
+import Setup from "@/test/Setup";
+import GoProteinCountTableProcessor from "@/business/processors/functional/go/GoProteinCountTableProcessor";
+import { GoNamespace } from "@/business/ontology/functional/go/GoNamespace";
+
+describe("FunctionalProteinCountTableProcessor", () => {
+    beforeAll(() => {
+        const setup = new Setup();
+        setup.setupAll();
+    });
+
+    it("correctly computes the trust for a peptide", async() => {
+        const goCountProcessor = new GoProteinCountTableProcessor("ATSST", true);
+
+        let trust = await goCountProcessor.getTrust();
+
+        // Only two out of three proteins are annotated with a GO-term.
+        expect(trust.annotatedItems).toBe(2);
+        expect(trust.totalAmountOfItems).toBe(3);
+    });
+
+    it("correctly returns counts over all namespaces", async() => {
+        const goCountProcessor = new GoProteinCountTableProcessor("ATSST", true);
+        const table = await goCountProcessor.getCountTable();
+
+        expect(table.getCounts("GO:0005737")).toBe(2);
+        expect(table.getCounts("GO:0005524")).toBe(1);
+        expect(table.getCounts("GO:0000000")).toBe(0);
+    });
+
+    it("correctly returns counts for one namespace", async() => {
+        const goCountProcessor = new GoProteinCountTableProcessor("ATSST", true);
+        const table = await goCountProcessor.getCountTable(GoNamespace.CellularComponent);
+
+        expect(table.getCounts("GO:0005737")).toBe(2);
+        expect(table.getCounts("GO:0005524")).toBe(0);
+        expect(table.getCounts("GO:0000000")).toBe(0);
+    });
+});

--- a/src/business/processors/functional/ec/EcProteinCountTableProcessor.ts
+++ b/src/business/processors/functional/ec/EcProteinCountTableProcessor.ts
@@ -1,0 +1,24 @@
+import FunctionalProteinCountTableProcessor
+    from "./../FunctionalProteinCountTableProcessor";
+import EcDefinition, { EcCode } from "./../../../ontology/functional/ec/EcDefinition";
+import ProteinDefinition from "./../../../ontology/protein/ProteinDefinition";
+import { FunctionalNamespace } from "./../../../ontology/functional/FunctionalNamespace";
+import { CountTable } from "./../../../counts/CountTable";
+import { Ontology } from "./../../../ontology/Ontology";
+import { EcNamespace } from "./../../../ontology/functional/ec/EcNamespace";
+import EcOntologyProcessor from "./../../../ontology/functional/ec/EcOntologyProcessor";
+
+export default class EcProteinCountTableProcessor extends FunctionalProteinCountTableProcessor<EcCode, EcDefinition> {
+    protected getAnnotationsFromProtein(p: ProteinDefinition): EcCode[] {
+        return p.ecNumbers;
+    }
+
+    protected getNamespaces(): FunctionalNamespace[] {
+        return Object.values(EcNamespace);
+    }
+
+    protected async getOntology(countTable: CountTable<EcCode>): Promise<Ontology<EcCode, EcDefinition>> {
+        const processor = new EcOntologyProcessor();
+        return await processor.getOntology(countTable);
+    }
+}

--- a/src/business/processors/functional/ec/EcProteinCountTableProcessor.ts
+++ b/src/business/processors/functional/ec/EcProteinCountTableProcessor.ts
@@ -7,8 +7,16 @@ import { CountTable } from "./../../../counts/CountTable";
 import { Ontology } from "./../../../ontology/Ontology";
 import { EcNamespace } from "./../../../ontology/functional/ec/EcNamespace";
 import EcOntologyProcessor from "./../../../ontology/functional/ec/EcOntologyProcessor";
+import { Peptide } from "./../../../ontology/raw/Peptide";
 
 export default class EcProteinCountTableProcessor extends FunctionalProteinCountTableProcessor<EcCode, EcDefinition> {
+    constructor(
+        peptide: Peptide,
+        equateIl: boolean,
+    ) {
+        super(peptide, equateIl, "EC:")
+    }
+
     protected getAnnotationsFromProtein(p: ProteinDefinition): EcCode[] {
         return p.ecNumbers;
     }

--- a/src/business/processors/functional/go/GoProteinCountTableProcessor.ts
+++ b/src/business/processors/functional/go/GoProteinCountTableProcessor.ts
@@ -6,8 +6,16 @@ import FunctionalProteinCountTableProcessor from "./../FunctionalProteinCountTab
 import ProteinDefinition from "./../../../ontology/protein/ProteinDefinition";
 import { FunctionalNamespace } from "./../../../ontology/functional/FunctionalNamespace";
 import { Ontology } from "./../../../ontology/Ontology";
+import { Peptide } from "./../../../ontology/raw/Peptide";
 
 export default class GoProteinCountTableProcessor extends FunctionalProteinCountTableProcessor<GoCode, GoDefinition>{
+    constructor(
+        peptide: Peptide,
+        equateIl: boolean
+    ) {
+        super(peptide, equateIl)
+    }
+
     protected getAnnotationsFromProtein(p: ProteinDefinition): GoCode[] {
         return p.goTerms;
     }

--- a/src/business/processors/functional/go/GoProteinCountTableProcessor.ts
+++ b/src/business/processors/functional/go/GoProteinCountTableProcessor.ts
@@ -1,85 +1,24 @@
-import CountTableProcessor from "./../../CountTableProcessor";
-import { GoCode } from "./../../../ontology/functional/go/GoDefinition";
+import GoDefinition, { GoCode } from "./../../../ontology/functional/go/GoDefinition";
 import { CountTable } from "./../../../counts/CountTable";
-import ProteinProcessor from "./../../protein/ProteinProcessor";
-import { Peptide } from "./../../../ontology/raw/Peptide";
 import { GoNamespace } from "./../../../ontology/functional/go/GoNamespace";
-import FunctionalTrust from "./../FunctionalTrust";
 import GoOntologyProcessor from "./../../../ontology/functional/go/GoOntologyProcessor";
+import FunctionalProteinCountTableProcessor from "./../FunctionalProteinCountTableProcessor";
+import ProteinDefinition from "./../../../ontology/protein/ProteinDefinition";
+import { FunctionalNamespace } from "./../../../ontology/functional/FunctionalNamespace";
+import { Ontology } from "./../../../ontology/Ontology";
 
-export default class GoProteinCountTableProcessor implements CountTableProcessor<GoCode>{
-    private countTables: Map<GoNamespace, CountTable<GoCode>> = new Map();
-    private generalCountTable: CountTable<GoCode>;
-    private trust: FunctionalTrust;
-
-    public constructor(
-        public readonly peptide: Peptide,
-        public readonly equateIl: boolean
-    ) {}
-
-    public async getCountTable(namespace?: GoNamespace): Promise<CountTable<GoCode>> {
-        await this.compute();
-        if (namespace) {
-            return this.countTables.get(namespace);
-        } else {
-            return this.generalCountTable;
-        }
+export default class GoProteinCountTableProcessor extends FunctionalProteinCountTableProcessor<GoCode, GoDefinition>{
+    protected getAnnotationsFromProtein(p: ProteinDefinition): GoCode[] {
+        return p.goTerms;
     }
 
-    public async getTrust(): Promise<FunctionalTrust> {
-        await this.compute();
-        return this.trust;
+    protected getNamespaces(): FunctionalNamespace[] {
+        return Object.values(GoNamespace);
     }
 
-    private async compute(): Promise<void> {
-        if (this.countTables.size > 0) {
-            return;
-        }
-
-        const proteinProcessor = new ProteinProcessor();
-        const proteins = await proteinProcessor.getProteinsByPeptide(this.peptide, this.equateIl);
-
-        // How many proteins are annotated with at least one GO-term?
-        let annotatedCount: number = 0;
-
-        const goTerms = proteins.reduce((acc, p) => {
-            if (p.goTerms && p.goTerms.length > 0) {
-                acc.push(...p.goTerms);
-                return acc;
-            } else {
-                annotatedCount++;
-            }
-        }, []);
-
-        const countsPerCode = new Map<GoCode, number>();
-        for (const term of goTerms) {
-            countsPerCode.set(term, (countsPerCode.get(term) || 0) + 1);
-        }
-
-        this.generalCountTable = new CountTable<GoCode>(countsPerCode);
-        this.trust = new FunctionalTrust(annotatedCount, proteins.length);
-
+    protected async getOntology(countTable: CountTable<GoCode>): Promise<Ontology<GoCode, GoDefinition>> {
         const ontologyProcessor = new GoOntologyProcessor();
-        const ontology = await ontologyProcessor.getOntology(this.generalCountTable);
-
-        // Split all the counts per namespace.
-        const tablePerNamespace = new Map<GoNamespace, Map<GoCode, number>>();
-
-        for (const ns of Object.values(GoNamespace)) {
-            tablePerNamespace.set(ns, new Map<GoCode, number>());
-        }
-
-        for (const [term, counts] of countsPerCode) {
-            const definition = ontology.getDefinition(term);
-
-            if (definition) {
-                const nsMap = tablePerNamespace.get(definition.namespace);
-                nsMap.set(term, counts);
-            }
-        }
-
-        for (const [ns, table] of tablePerNamespace) {
-            this.countTables.set(ns, new CountTable<GoCode>(table));
-        }
+        return await ontologyProcessor.getOntology(countTable);
     }
+
 }

--- a/src/business/processors/functional/go/GoProteinCountTableProcessor.ts
+++ b/src/business/processors/functional/go/GoProteinCountTableProcessor.ts
@@ -1,0 +1,85 @@
+import CountTableProcessor from "./../../CountTableProcessor";
+import { GoCode } from "./../../../ontology/functional/go/GoDefinition";
+import { CountTable } from "./../../../counts/CountTable";
+import ProteinProcessor from "./../../protein/ProteinProcessor";
+import { Peptide } from "./../../../ontology/raw/Peptide";
+import { GoNamespace } from "./../../../ontology/functional/go/GoNamespace";
+import FunctionalTrust from "./../FunctionalTrust";
+import GoOntologyProcessor from "./../../../ontology/functional/go/GoOntologyProcessor";
+
+export default class GoProteinCountTableProcessor implements CountTableProcessor<GoCode>{
+    private countTables: Map<GoNamespace, CountTable<GoCode>> = new Map();
+    private generalCountTable: CountTable<GoCode>;
+    private trust: FunctionalTrust;
+
+    public constructor(
+        public readonly peptide: Peptide,
+        public readonly equateIl: boolean
+    ) {}
+
+    public async getCountTable(namespace?: GoNamespace): Promise<CountTable<GoCode>> {
+        await this.compute();
+        if (namespace) {
+            return this.countTables.get(namespace);
+        } else {
+            return this.generalCountTable;
+        }
+    }
+
+    public async getTrust(): Promise<FunctionalTrust> {
+        await this.compute();
+        return this.trust;
+    }
+
+    private async compute(): Promise<void> {
+        if (this.countTables.size > 0) {
+            return;
+        }
+
+        const proteinProcessor = new ProteinProcessor();
+        const proteins = await proteinProcessor.getProteinsByPeptide(this.peptide, this.equateIl);
+
+        // How many proteins are annotated with at least one GO-term?
+        let annotatedCount: number = 0;
+
+        const goTerms = proteins.reduce((acc, p) => {
+            if (p.goTerms && p.goTerms.length > 0) {
+                acc.push(...p.goTerms);
+                return acc;
+            } else {
+                annotatedCount++;
+            }
+        }, []);
+
+        const countsPerCode = new Map<GoCode, number>();
+        for (const term of goTerms) {
+            countsPerCode.set(term, (countsPerCode.get(term) || 0) + 1);
+        }
+
+        this.generalCountTable = new CountTable<GoCode>(countsPerCode);
+        this.trust = new FunctionalTrust(annotatedCount, proteins.length);
+
+        const ontologyProcessor = new GoOntologyProcessor();
+        const ontology = await ontologyProcessor.getOntology(this.generalCountTable);
+
+        // Split all the counts per namespace.
+        const tablePerNamespace = new Map<GoNamespace, Map<GoCode, number>>();
+
+        for (const ns of Object.values(GoNamespace)) {
+            tablePerNamespace.set(ns, new Map<GoCode, number>());
+        }
+
+        for (const [term, counts] of countsPerCode) {
+            const definition = ontology.getDefinition(term);
+
+            if (definition) {
+                const nsMap = tablePerNamespace.get(definition.namespace);
+                nsMap.set(term, counts);
+            }
+        }
+
+        for (const [ns, table] of tablePerNamespace) {
+            this.countTables.set(ns, new CountTable<GoCode>(table));
+        }
+    }
+}

--- a/src/business/processors/functional/go/GoProteinCountTableProcessor.ts
+++ b/src/business/processors/functional/go/GoProteinCountTableProcessor.ts
@@ -20,5 +20,4 @@ export default class GoProteinCountTableProcessor extends FunctionalProteinCount
         const ontologyProcessor = new GoOntologyProcessor();
         return await ontologyProcessor.getOntology(countTable);
     }
-
 }

--- a/src/business/processors/functional/interpro/InterproProteinCountTableProcessor.ts
+++ b/src/business/processors/functional/interpro/InterproProteinCountTableProcessor.ts
@@ -1,0 +1,25 @@
+import FunctionalProteinCountTableProcessor
+    from "./../FunctionalProteinCountTableProcessor";
+import InterproDefinition, { InterproCode } from "./../../../ontology/functional/interpro/InterproDefinition";
+import ProteinDefinition from "./../../../ontology/protein/ProteinDefinition";
+import { FunctionalNamespace } from "./../../../ontology/functional/FunctionalNamespace";
+import { CountTable } from "./../../../counts/CountTable";
+import { Ontology } from "./../../../ontology/Ontology";
+import { InterproNamespace } from "@/business/ontology/functional/interpro/InterproNamespace";
+import InterproOntologyProcessor from "@/business/ontology/functional/interpro/InterproOntologyProcessor";
+
+export default class InterproProteinCountTableProcessor extends FunctionalProteinCountTableProcessor<InterproCode, InterproDefinition> {
+    protected getAnnotationsFromProtein(p: ProteinDefinition): InterproCode[] {
+        return p.interproEntries;
+    }
+
+    protected getNamespaces(): FunctionalNamespace[] {
+        return Object.values(InterproNamespace);
+    }
+
+    protected async getOntology(countTable: CountTable<InterproCode>): Promise<Ontology<InterproCode, InterproDefinition>> {
+        const processor = new InterproOntologyProcessor();
+        return await processor.getOntology(countTable);
+    }
+
+}

--- a/src/business/processors/functional/interpro/InterproProteinCountTableProcessor.ts
+++ b/src/business/processors/functional/interpro/InterproProteinCountTableProcessor.ts
@@ -5,10 +5,18 @@ import ProteinDefinition from "./../../../ontology/protein/ProteinDefinition";
 import { FunctionalNamespace } from "./../../../ontology/functional/FunctionalNamespace";
 import { CountTable } from "./../../../counts/CountTable";
 import { Ontology } from "./../../../ontology/Ontology";
-import { InterproNamespace } from "@/business/ontology/functional/interpro/InterproNamespace";
-import InterproOntologyProcessor from "@/business/ontology/functional/interpro/InterproOntologyProcessor";
+import { InterproNamespace } from "./../../../ontology/functional/interpro/InterproNamespace";
+import InterproOntologyProcessor from "./../../..//ontology/functional/interpro/InterproOntologyProcessor";
+import { Peptide } from "./../../..//ontology/raw/Peptide";
 
 export default class InterproProteinCountTableProcessor extends FunctionalProteinCountTableProcessor<InterproCode, InterproDefinition> {
+    constructor(
+        peptide: Peptide,
+        equateIl: boolean,
+    ) {
+        super(peptide, equateIl, "IPR:")
+    }
+
     protected getAnnotationsFromProtein(p: ProteinDefinition): InterproCode[] {
         return p.interproEntries;
     }

--- a/src/components/analysis/functional/EcSummaryCard.vue
+++ b/src/components/analysis/functional/EcSummaryCard.vue
@@ -189,6 +189,8 @@ export default class EcSummaryCard extends Vue {
 
         const sortedEcs = ecCountTable.getOntologyIds()
             .map(id => ecOntology.getDefinition(id))
+            // Only retain valid definitions
+            .filter(def => def)
             .sort((a: EcDefinition, b: EcDefinition) => a.level - b.level);
 
         for (const ecDef of sortedEcs) {

--- a/src/components/analysis/functional/EcSummaryCard.vue
+++ b/src/components/analysis/functional/EcSummaryCard.vue
@@ -1,18 +1,19 @@
 <template>
     <v-card flat>
         <v-card-text>
-            <div v-if="!ecCountTable">
-                <span class="ec-waiting" v-if="loading">
-                    <v-progress-circular :size="70" :width="7" color="primary" indeterminate></v-progress-circular>
-                </span>
-                <span v-else class="placeholder-text">
+            <div v-if="!analysisInProgress">
+                <span class="placeholder-text">
                     Please select at least one dataset for analysis.
+                </span>
+            </div>
+            <div v-else-if="loading">
+                <span class="ec-waiting">
+                    <v-progress-circular :size="70" :width="7" color="primary" indeterminate></v-progress-circular>
                 </span>
             </div>
             <div v-else>
                 <slot name="analysis-header"></slot>
 
-                <span>Click on a row in a table to see a taxonomy tree that highlights occurrences.</span>
                 <ec-amount-table
                     :loading="isLoading"
                     :ec-count-table="ecCountTable"
@@ -95,6 +96,8 @@ export default class EcSummaryCard extends Vue {
     private searchConfiguration: SearchConfiguration;
     @Prop({ required: false, default: false })
     private loading: boolean;
+    @Prop({ required: false, default: true })
+    private analysisInProgress: boolean;
     @Prop({ required: true })
     private relativeCounts: number;
     @Prop({ required: false, default: false })

--- a/src/components/analysis/functional/FunctionalSummaryCard.vue
+++ b/src/components/analysis/functional/FunctionalSummaryCard.vue
@@ -104,7 +104,7 @@
             </v-alert>
             <v-tabs-items v-model="currentTab">
                 <v-tab-item>
-                    <go-summary-card
+                    <multi-go-summary-card
                         v-if="filteredCountTable"
                         ref="goSummaryCard"
                         :peptide-count-table="filteredCountTable"
@@ -113,7 +113,7 @@
                         :show-percentage="showPercentage"
                         :tree="tree"
                         :taxa-to-peptides-mapping="taxaToPeptidesMapping">
-                    </go-summary-card>
+                    </multi-go-summary-card>
                     <div v-else-if="this.analysisInProgress" class="mpa-waiting">
                         <v-progress-circular :size="70" :width="7" color="primary" indeterminate>
                         </v-progress-circular>
@@ -197,9 +197,11 @@ import PeptideCountTableProcessor from "./../../../business/processors/raw/Pepti
 import NcbiOntologyProcessor from "./../../../business/ontology/taxonomic/ncbi/NcbiOntologyProcessor";
 import Tree from "./../../../business/ontology/taxonomic/Tree";
 import TreeNode from "./../../../business/ontology/taxonomic/TreeNode";
+import MultiGoSummaryCard from "./../multi/MultiGoSummaryCard.vue";
 
 @Component({
     components: {
+        MultiGoSummaryCard,
         CardHeader,
         IndeterminateProgressBar,
         FilterFunctionalAnnotationsDropdown,

--- a/src/components/analysis/functional/FunctionalSummaryCard.vue
+++ b/src/components/analysis/functional/FunctionalSummaryCard.vue
@@ -125,7 +125,7 @@
                     </div>
                 </v-tab-item>
                 <v-tab-item>
-                    <ec-summary-card
+                    <multi-ec-summary-card
                         v-if="filteredCountTable"
                         ref="ecSummaryCard"
                         :peptide-count-table="filteredCountTable"
@@ -134,7 +134,7 @@
                         :show-percentage="showPercentage"
                         :tree="tree"
                         :taxa-to-peptides-mapping="taxaToPeptidesMapping">
-                    </ec-summary-card>
+                    </multi-ec-summary-card>
                     <div v-else-if="this.analysisInProgress" class="mpa-waiting">
                         <v-progress-circular :size="70" :width="7" color="primary" indeterminate>
                         </v-progress-circular>
@@ -181,7 +181,7 @@ import FilterFunctionalAnnotationsDropdown from "./FilterFunctionalAnnotationsDr
 
 import IndeterminateProgressBar from "../../custom/IndeterminateProgressBar.vue";
 import CardHeader from "../../custom/CardHeader.vue";
-import QuickGoCard from "./QuickGOCard.vue";
+import QuickGoCard from "./QuickGoCard.vue";
 
 import ImageDownloadModal from "../../utils/ImageDownloadModal.vue";
 
@@ -198,9 +198,11 @@ import NcbiOntologyProcessor from "./../../../business/ontology/taxonomic/ncbi/N
 import Tree from "./../../../business/ontology/taxonomic/Tree";
 import TreeNode from "./../../../business/ontology/taxonomic/TreeNode";
 import MultiGoSummaryCard from "./../multi/MultiGoSummaryCard.vue";
+import MultiEcSummaryCard from "./../multi/MultiEcSummaryCard.vue";
 
 @Component({
     components: {
+        MultiEcSummaryCard,
         MultiGoSummaryCard,
         CardHeader,
         IndeterminateProgressBar,

--- a/src/components/analysis/functional/FunctionalSummaryCard.vue
+++ b/src/components/analysis/functional/FunctionalSummaryCard.vue
@@ -146,7 +146,7 @@
                     </div>
                 </v-tab-item>
                 <v-tab-item>
-                    <interpro-summary-card
+                    <multi-interpro-summary-card
                         v-if="filteredCountTable"
                         ref="interproSummaryCard"
                         :peptide-count-table="filteredCountTable"
@@ -155,7 +155,7 @@
                         :show-percentage="showPercentage"
                         :tree="tree"
                         :taxa-to-peptides-mapping="taxaToPeptidesMapping">
-                    </interpro-summary-card>
+                    </multi-interpro-summary-card>
                     <div v-else-if="this.analysisInProgress" class="mpa-waiting">
                         <v-progress-circular :size="70" :width="7" color="primary" indeterminate>
                         </v-progress-circular>
@@ -185,9 +185,6 @@ import QuickGoCard from "./QuickGoCard.vue";
 
 import ImageDownloadModal from "../../utils/ImageDownloadModal.vue";
 
-import GoSummaryCard from "./GoSummaryCard.vue";
-import EcSummaryCard from "./EcSummaryCard.vue";
-import InterproSummaryCard from "./InterproSummaryCard.vue";
 import { Peptide } from "./../../../business/ontology/raw/Peptide";
 import { CountTable } from "./../../../business/counts/CountTable";
 import NcbiTaxon, { NcbiId } from "./../../../business/ontology/taxonomic/ncbi/NcbiTaxon";
@@ -199,27 +196,26 @@ import Tree from "./../../../business/ontology/taxonomic/Tree";
 import TreeNode from "./../../../business/ontology/taxonomic/TreeNode";
 import MultiGoSummaryCard from "./../multi/MultiGoSummaryCard.vue";
 import MultiEcSummaryCard from "./../multi/MultiEcSummaryCard.vue";
+import MultiInterproSummaryCard from "./../multi/MultiInterproSummaryCard.vue";
 
 @Component({
     components: {
         MultiEcSummaryCard,
         MultiGoSummaryCard,
+        MultiInterproSummaryCard,
         CardHeader,
         IndeterminateProgressBar,
         FilterFunctionalAnnotationsDropdown,
         QuickGoCard,
         ImageDownloadModal,
-        GoSummaryCard,
-        EcSummaryCard,
-        InterproSummaryCard
     }
 })
 export default class FunctionalSummaryCard extends Vue {
     $refs!: {
         imageDownloadModal: ImageDownloadModal,
-        goSummaryCard: GoSummaryCard,
-        ecSummaryCard: EcSummaryCard,
-        interproSummaryCard: InterproSummaryCard
+        goSummaryCard: MultiGoSummaryCard,
+        ecSummaryCard: MultiEcSummaryCard,
+        interproSummaryCard: MultiInterproSummaryCard
     }
 
     @Prop({ required: true })

--- a/src/components/analysis/functional/FunctionalSummaryMixin.vue
+++ b/src/components/analysis/functional/FunctionalSummaryMixin.vue
@@ -17,16 +17,16 @@ export default class FunctionalSummaryMixin extends Vue {
      * @return
      */
     protected computeTrustLine(trust: FunctionalTrust, kind: string): string {
-        if (trust.annotatedPeptides === 0) {
+        if (trust.annotatedItems === 0) {
             return `<strong>No peptide</strong> has a ${kind} assigned to it. `;
         }
-        if (trust.annotatedPeptides === trust.totalAmountOfPeptides) {
-            return `<strong>All peptides</strong> ${trust.annotatedPeptides <= 5 ? `(only ${trust.annotatedPeptides})` : ""} have at least one ${kind} assigned to them. `;
+        if (trust.annotatedItems === trust.totalAmountOfItems) {
+            return `<strong>All peptides</strong> ${trust.annotatedItems <= 5 ? `(only ${trust.annotatedItems})` : ""} have at least one ${kind} assigned to them. `;
         }
-        if (trust.annotatedPeptides === 1) {
-            return `Only <strong>one peptide</strong> (${StringUtils.numberToPercent(trust.annotatedPeptides / trust.totalAmountOfPeptides)}) has at least one ${kind} assigned to it. `;
+        if (trust.annotatedItems === 1) {
+            return `Only <strong>one peptide</strong> (${StringUtils.numberToPercent(trust.annotatedItems / trust.totalAmountOfItems)}) has at least one ${kind} assigned to it. `;
         }
-        return `<strong>${trust.annotatedPeptides}</strong> (${StringUtils.numberToPercent(trust.annotatedPeptides / trust.totalAmountOfPeptides)}) have at least one ${kind} assigned to them. `;
+        return `<strong>${trust.annotatedItems}</strong> (${StringUtils.numberToPercent(trust.annotatedItems / trust.totalAmountOfItems)}) have at least one ${kind} assigned to them. `;
     }
 }
 </script>

--- a/src/components/analysis/functional/FunctionalUtils.ts
+++ b/src/components/analysis/functional/FunctionalUtils.ts
@@ -6,19 +6,17 @@ export class FunctionalUtils {
      * Creates a line indicating the trust of the function annotations
      *
      * @param trust The FunctionalTrust-object that contains all necessary trust information.
-     * @param kind Human readable word that fits in "To have at least one … assigned to it"
+     * @param faKind Human readable word that fits in "To have at least one … assigned to it". Provide in singular.
+     * @param countKind Human readable word that fits in "No ... has a x assigned to it". Provide in singular.
      * @return A string describing the trust information, with correct pluralization.
      */
-    public static computeTrustLine(trust: FunctionalTrust, kind: string): string {
-        if (trust.annotatedPeptides === 0) {
-            return `<strong>No peptide</strong> has a ${kind} assigned to it. `;
+    public static computeTrustLine(trust: FunctionalTrust, faKind: string, countKind: string): string {
+        if (trust.annotatedItems === 0) {
+            return `<strong>No ${countKind}</strong> has a ${faKind} assigned to it. `;
+        } else if (trust.annotatedItems === trust.totalAmountOfItems) {
+            return `<strong>All ${countKind}s</strong> ${trust.annotatedItems <= 5 ? `(only ${trust.annotatedItems})` : ""} have at least one ${faKind} assigned to them. `;
+        } else if (trust.annotatedItems === 1) {
+            return `Only <strong>one ${countKind}</strong> (${StringUtils.numberToPercent(trust.annotatedItems / trust.totalAmountOfItems)}) has at least one ${faKind} assigned to it. `;
         }
-        if (trust.annotatedPeptides === trust.totalAmountOfPeptides) {
-            return `<strong>All peptides</strong> ${trust.annotatedPeptides <= 5 ? `(only ${trust.annotatedPeptides})` : ""} have at least one ${kind} assigned to them. `;
-        }
-        if (trust.annotatedPeptides === 1) {
-            return `Only <strong>one peptide</strong> (${StringUtils.numberToPercent(trust.annotatedPeptides / trust.totalAmountOfPeptides)}) has at least one ${kind} assigned to it. `;
-        }
-        return `<strong>${trust.annotatedPeptides}</strong> (${StringUtils.numberToPercent(trust.annotatedPeptides / trust.totalAmountOfPeptides)}) have at least one ${kind} assigned to them. `;
     }
 }

--- a/src/components/analysis/functional/FunctionalUtils.ts
+++ b/src/components/analysis/functional/FunctionalUtils.ts
@@ -1,0 +1,24 @@
+import FunctionalTrust from "./../../../business/processors/functional/FunctionalTrust";
+import StringUtils from "./../../../business/misc/StringUtils";
+
+export class FunctionalUtils {
+    /**
+     * Creates a line indicating the trust of the function annotations
+     *
+     * @param trust The FunctionalTrust-object that contains all necessary trust information.
+     * @param kind Human readable word that fits in "To have at least one … assigned to it"
+     * @return A string describing the trust information, with correct pluralization.
+     */
+    public static computeTrustLine(trust: FunctionalTrust, kind: string): string {
+        if (trust.annotatedPeptides === 0) {
+            return `<strong>No peptide</strong> has a ${kind} assigned to it. `;
+        }
+        if (trust.annotatedPeptides === trust.totalAmountOfPeptides) {
+            return `<strong>All peptides</strong> ${trust.annotatedPeptides <= 5 ? `(only ${trust.annotatedPeptides})` : ""} have at least one ${kind} assigned to them. `;
+        }
+        if (trust.annotatedPeptides === 1) {
+            return `Only <strong>one peptide</strong> (${StringUtils.numberToPercent(trust.annotatedPeptides / trust.totalAmountOfPeptides)}) has at least one ${kind} assigned to it. `;
+        }
+        return `<strong>${trust.annotatedPeptides}</strong> (${StringUtils.numberToPercent(trust.annotatedPeptides / trust.totalAmountOfPeptides)}) have at least one ${kind} assigned to them. `;
+    }
+}

--- a/src/components/analysis/functional/FunctionalUtils.ts
+++ b/src/components/analysis/functional/FunctionalUtils.ts
@@ -14,9 +14,11 @@ export class FunctionalUtils {
         if (trust.annotatedItems === 0) {
             return `<strong>No ${countKind}</strong> has a ${faKind} assigned to it. `;
         } else if (trust.annotatedItems === trust.totalAmountOfItems) {
-            return `<strong>All ${countKind}s</strong> ${trust.annotatedItems <= 5 ? `(only ${trust.annotatedItems})` : ""} have at least one ${faKind} assigned to them. `;
+            return `<strong>All ${countKind}s</strong> have at least one ${faKind} assigned to them. `;
         } else if (trust.annotatedItems === 1) {
             return `Only <strong>one ${countKind}</strong> (${StringUtils.numberToPercent(trust.annotatedItems / trust.totalAmountOfItems)}) has at least one ${faKind} assigned to it. `;
+        } else {
+            return `<strong>${trust.annotatedItems} ${countKind}s</strong> (${StringUtils.numberToPercent(trust.annotatedItems / trust.totalAmountOfItems)}) have at least one ${faKind} assigned to them. `;
         }
     }
 }

--- a/src/components/analysis/functional/GoSummary.vue
+++ b/src/components/analysis/functional/GoSummary.vue
@@ -1,0 +1,110 @@
+<docs>
+    This component displays both a GoAmountTable and a QuickGoCard. By providing the `loading` prop, the loading state
+    of this component will be triggered.
+</docs>
+
+<template>
+    <v-row>
+        <v-col :cols="9">
+            <go-amount-table
+                :loading="loading"
+                :namespace="namespace"
+                :go-count-table="goCountTable"
+                :go-peptide-mapping="goPeptideMapping"
+                :go-ontology="goOntology"
+                :relative-counts="relativeCounts"
+                :search-configuration="searchConfiguration"
+                :show-percentage="showPercentage"
+                :taxa-to-peptides-mapping="taxaToPeptidesMapping"
+                :tree="tree">
+            </go-amount-table>
+        </v-col>
+        <v-col :cols="3">
+            <quick-go-card :items="definitions">
+            </quick-go-card>
+        </v-col>
+    </v-row>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import Component from "vue-class-component";
+import { Prop, Watch } from "vue-property-decorator";
+import GoAmountTable from "./../../tables/GoAmountTable.vue"
+import QuickGoCard from "./QuickGOCard.vue";
+import GoDefinition, { GoCode } from "./../../../business/ontology/functional/go/GoDefinition";
+import { CountTable } from "./../../../business/counts/CountTable";
+import { Ontology } from "./../../../business/ontology/Ontology";
+import SearchConfiguration from "./../../../business/configuration/SearchConfiguration";
+import { Peptide } from "./../../../business/ontology/raw/Peptide";
+import { NcbiId } from "./../../../business/ontology/taxonomic/ncbi/NcbiTaxon";
+import Tree from "./../../../business/ontology/taxonomic/Tree";
+
+@Component({
+    components: {
+        GoAmountTable,
+        QuickGoCard
+    }
+})
+export default class GoSummary extends Vue {
+    @Prop({ required: true })
+    private namespace: string;
+    @Prop({ required: true })
+    private goCountTable: CountTable<GoCode>;
+    @Prop({ required: true })
+    private goOntology: Ontology<GoCode, GoDefinition>;
+    @Prop({ required: true })
+    private relativeCounts: number;
+    /**
+     * Maps a GO-term onto all peptides that are annotated with the term. If this is not provided, no TreeView or
+     * per-row-exports will be provided.
+     */
+    @Prop({ required: false })
+    private goPeptideMapping;
+    /**
+     * The search settings that need be respected while processing peptide-related data. If this is not provided, no
+     * TreeView or per-row-exports will be provided.
+     */
+    @Prop({ required: false })
+    private searchConfiguration: SearchConfiguration;
+    /**
+     * Do we show the counts in an absolute or relative manner? If this is set to true, the relative counts will be
+     * displayed. Otherwise the absolute will be given.
+     */
+    @Prop({ required: false, default: false })
+    private showPercentage: boolean;
+    /**
+     * Mapping from taxa to the peptides that were annotated with this taxon. If this is not set, no TreeView will be
+     * provided.
+     */
+    @Prop({ required: false })
+    private taxaToPeptidesMapping: Map<NcbiId, Peptide[]>;
+    /**
+     * A tree with the complete lca-lineage in which filtering by the taxa associated with a given GO-term should occur.
+     * If this is not set, no TreeView will be provided.
+     */
+    @Prop({ required: false })
+    private tree: Tree;
+    @Prop({ required: false, default: false })
+    private loading: boolean;
+
+    // A list of all GO-terms that should be displayed in this component.
+    private definitions: GoDefinition[];
+
+    private mounted() {
+        this.onInputsChanged();
+    }
+
+    @Watch("goCountTable")
+    @Watch("goOntology")
+    private onInputsChanged() {
+        if (this.goCountTable && this.goOntology) {
+            this.definitions = this.goCountTable.getOntologyIds().map(id => this.goOntology.getDefinition(id));
+        }
+    }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/src/components/analysis/functional/GoSummary.vue
+++ b/src/components/analysis/functional/GoSummary.vue
@@ -31,7 +31,7 @@ import Vue from "vue";
 import Component from "vue-class-component";
 import { Prop, Watch } from "vue-property-decorator";
 import GoAmountTable from "./../../tables/GoAmountTable.vue"
-import QuickGoCard from "./QuickGOCard.vue";
+import QuickGoCard from "./QuickGoCard.vue";
 import GoDefinition, { GoCode } from "./../../../business/ontology/functional/go/GoDefinition";
 import { CountTable } from "./../../../business/counts/CountTable";
 import { Ontology } from "./../../../business/ontology/Ontology";

--- a/src/components/analysis/functional/InterproSummaryCard.vue
+++ b/src/components/analysis/functional/InterproSummaryCard.vue
@@ -67,7 +67,7 @@ export default class InterproSummaryCard extends mixins(FunctionalSummaryMixin) 
     private interproOntology: (ns: string) => Promise<Ontology<InterproCode, InterproDefinition>>;
     @Prop({ required: false })
     private interproPeptideMapping: Map<InterproCode, Peptide[]>;
-    @Prop({ required: true })
+    @Prop({ required: false })
     private searchConfiguration: SearchConfiguration;
     @Prop({ required: false, default: false })
     private loading: boolean;

--- a/src/components/analysis/functional/QuickGoCard.vue
+++ b/src/components/analysis/functional/QuickGoCard.vue
@@ -31,7 +31,7 @@ import Utils from "./../../custom/Utils";
 import GoDefinition from "./../../../business/ontology/functional/go/GoDefinition";
 
 @Component
-export default class QuickGOCard extends Vue {
+export default class QuickGoCard extends Vue {
     @Prop({ required: true })
     private items: GoDefinition[];
 

--- a/src/components/analysis/functional/__tests__/FunctionalUtils.spec.ts
+++ b/src/components/analysis/functional/__tests__/FunctionalUtils.spec.ts
@@ -1,0 +1,56 @@
+import { FunctionalUtils } from "@/components/analysis/functional/FunctionalUtils";
+import FunctionalTrust from "@/business/processors/functional/FunctionalTrust";
+
+describe("FunctionalUtils", () => {
+    /**
+     * Test if the correct string is produced when no annotated items were found.
+     */
+    it("correctly produces a trust string for no items", () => {
+        expect(
+            FunctionalUtils.computeTrustLine(
+                new FunctionalTrust(0, 100),
+                "GO-term",
+                "peptide"
+            )
+        ).toEqual("<strong>No peptide</strong> has a GO-term assigned to it. ");
+
+        // Also test that other kinds are correctly interpolated.
+        expect(
+            FunctionalUtils.computeTrustLine(
+                new FunctionalTrust(0, 100),
+                "EC-number",
+                "protein"
+            )
+        ).toEqual("<strong>No protein</strong> has a EC-number assigned to it. ");
+    });
+
+    it("correctly produces a trust string for one item", () => {
+        expect(
+            FunctionalUtils.computeTrustLine(
+                new FunctionalTrust(1, 100),
+                "GO-term",
+                "peptide"
+            )
+        ).toEqual("Only <strong>one peptide</strong> (1%) has at least one GO-term assigned to it. ");
+    });
+
+    it("correctly produces a trust string for multiple items", () => {
+        expect(
+            FunctionalUtils.computeTrustLine(
+                new FunctionalTrust(5, 100),
+                "GO-term",
+                "peptide"
+            )
+        ).toEqual("<strong>5 peptides</strong> (5%) have at least one GO-term assigned to them. ");
+    });
+
+    it("correctly produces a trust string if all items are annotated", () => {
+        expect(
+            FunctionalUtils.computeTrustLine(
+                new FunctionalTrust(100, 100),
+                "GO-term",
+                "peptide"
+            )
+        ).toEqual("<strong>All peptides</strong> have at least one GO-term assigned to them. ");
+    });
+});

--- a/src/components/analysis/functional/__tests__/GoSummaryCard.spec.ts
+++ b/src/components/analysis/functional/__tests__/GoSummaryCard.spec.ts
@@ -1,0 +1,39 @@
+import Setup from "@/test/Setup";
+import Vue from "vue"
+import Vuetify from "vuetify"
+import { createLocalVue, mount } from "@vue/test-utils";
+import { waitForCondition, waitForElement } from "@/test/Utils";
+import GoSummaryCard from "@/components/analysis/functional/GoSummaryCard.vue";
+
+Vue.use(Vuetify);
+
+const localVue = createLocalVue();
+
+describe("GoSummaryCard", () => {
+    let vuetify;
+
+    beforeEach(() => {
+        vuetify = new Vuetify();
+    });
+
+    beforeAll(() => {
+        const setup = new Setup();
+        setup.setupAll();
+    });
+
+    it("shows all loading indicators when it switches to the loading state", async() => {
+        const wrapper = mount(GoSummaryCard, {
+            localVue,
+            vuetify,
+            propsData: {
+                loading: true
+            },
+            sync: false
+        });
+
+        await waitForElement(wrapper, ".go-waiting");
+
+        // 3 circular progress indicators should be shown (one for each namespace) when the loading state is enabled.
+        expect(wrapper.findAll(".v-progress-circular").length).toBe(3);
+    });
+});

--- a/src/components/analysis/functional/__tests__/QuickGOCard.spec.ts
+++ b/src/components/analysis/functional/__tests__/QuickGOCard.spec.ts
@@ -1,5 +1,5 @@
 import { createLocalVue, shallowMount } from "@vue/test-utils"
-import QuickGOCard from "./../QuickGOCard.vue";
+import QuickGoCard from "./../QuickGoCard.vue";
 import Vue from "vue"
 import Vuetify from "vuetify"
 import GoDefinition from "@/business/ontology/functional/go/GoDefinition";
@@ -9,7 +9,7 @@ Vue.use(Vuetify);
 
 const localVue = createLocalVue();
 
-describe("QuickGOSummaryCard", () => {
+describe("QuickGoCard", () => {
     let vuetify;
 
     beforeEach(() => {
@@ -17,7 +17,7 @@ describe("QuickGOSummaryCard", () => {
     });
 
     it("renders a placeholder when no GO-terms are found", () => {
-        const wrapper = shallowMount(QuickGOCard, {
+        const wrapper = shallowMount(QuickGoCard, {
             localVue,
             vuetify,
             propsData: {
@@ -49,7 +49,7 @@ describe("QuickGOSummaryCard", () => {
             GoNamespace.BiologicalProcess
         ));
 
-        const wrapper = shallowMount(QuickGOCard, {
+        const wrapper = shallowMount(QuickGoCard, {
             localVue,
             vuetify,
             propsData: {

--- a/src/components/analysis/functional/__tests__/__snapshots__/QuickGOCard.spec.ts.snap
+++ b/src/components/analysis/functional/__tests__/__snapshots__/QuickGOCard.spec.ts.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`QuickGOSummaryCard renders a placeholder when no GO-terms are found 1`] = `
+exports[`QuickGoCard renders a placeholder when no GO-terms are found 1`] = `
 "<v-card-text-stub>
                 No GO terms for this domain were found.
             </v-card-text-stub>"
 `;
 
-exports[`QuickGOSummaryCard renders valid GO-terms correctly 1`] = `
+exports[`QuickGoCard renders valid GO-terms correctly 1`] = `
 "<v-card-text-stub>
                 This chart shows the relationship between the 3 most occurring GO terms:
                 translation, neutrophil degranulation and protein refolding.

--- a/src/components/analysis/multi/MultiEcSummaryCard.vue
+++ b/src/components/analysis/multi/MultiEcSummaryCard.vue
@@ -1,0 +1,105 @@
+<template>
+    <ec-summary-card
+        :ec-count-table="ecCountTable"
+        :ec-ontology="ecOntology"
+        :ec-peptide-mapping="ecPeptideMapping"
+        :taxa-to-peptides-mapping="taxaToPeptidesMapping"
+        :show-percentage="showPercentage"
+        :search-configuration="searchConfiguration"
+        :tree="tree"
+        :loading="calculationsInProgress"
+        :relative-counts="relativeCounts">
+        <template v-slot:analysis-header>
+            <filter-functional-annotations-dropdown v-model="percentSettings">
+            </filter-functional-annotations-dropdown>
+            <span>This panel shows the Enzyme Commission numbers that were matched to your peptides. </span>
+            <span v-html="trustLine"></span>
+        </template>
+    </ec-summary-card>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import Component from "vue-class-component";
+import EcSummaryCard from "./../functional/EcSummaryCard.vue";
+import FilterFunctionalAnnotationsDropdown from "./../functional/FilterFunctionalAnnotationsDropdown.vue";
+import { Prop, Watch } from "vue-property-decorator";
+import EcCountTableProcessor from "./../../../business/processors/functional/ec/EcCountTableProcessor";
+import EcOntologyProcessor from "./../../../business/ontology/functional/ec/EcOntologyProcessor";
+import { Peptide } from "./../../../business/ontology/raw/Peptide";
+import { CountTable } from "./../../../business/counts/CountTable";
+import SearchConfiguration from "./../../../business/configuration/SearchConfiguration";
+import EcDefinition, { EcCode } from "./../../../business/ontology/functional/ec/EcDefinition";
+import { Ontology } from "./../../../business/ontology/Ontology";
+import { FunctionalUtils } from "./../functional/FunctionalUtils";
+import { NcbiId } from "./../../../business/ontology/taxonomic/ncbi/NcbiTaxon";
+import Tree from "./../../../business/ontology/taxonomic/Tree";
+import FunctionalTrust from "./../../../business/processors/functional/FunctionalTrust";
+
+@Component({
+    components: { EcSummaryCard, FilterFunctionalAnnotationsDropdown }
+})
+export default class MultiEcSummaryCard extends Vue {
+    @Prop({ required: true })
+    private peptideCountTable: CountTable<Peptide>;
+    @Prop({ required: true })
+    private searchConfiguration: SearchConfiguration;
+    @Prop({ required: true })
+    private relativeCounts: number;
+    @Prop({ required: false, default: false })
+    private showPercentage: boolean;
+    @Prop({ required: false })
+    protected taxaToPeptidesMapping: Map<NcbiId, Peptide[]>;
+    @Prop({ required: false })
+    protected tree: Tree;
+
+    private ecCountTable: CountTable<EcCode> = null;
+    private ecPeptideMapping: Map<EcCode, Peptide[]> = null;
+    private ecOntology: Ontology<EcCode, EcDefinition> = null;
+
+    private trust: FunctionalTrust = null;
+    private trustLine: string = "";
+    private percentSettings: string = "5";
+
+    private calculationsInProgress: boolean = false;
+
+    private mounted() {
+        this.recompute();
+    }
+
+    @Watch("peptideCountTable")
+    @Watch("searchConfiguration")
+    private async recompute() {
+        this.calculationsInProgress = true;
+        console.log("peptide count table");
+        console.log(this.peptideCountTable);
+        if (this.peptideCountTable) {
+            const percentage = parseInt(this.percentSettings);
+            const ecCountTableProcessor = new EcCountTableProcessor(
+                this.peptideCountTable,
+                this.searchConfiguration,
+                percentage
+            );
+            this.ecCountTable = await ecCountTableProcessor.getCountTable();
+            this.ecPeptideMapping = await ecCountTableProcessor.getAnnotationPeptideMapping();
+
+            const ontologyProcessor = new EcOntologyProcessor();
+            this.ecOntology = await ontologyProcessor.getOntology(this.ecCountTable);
+
+            this.trust = await ecCountTableProcessor.getTrust();
+            this.trustLine = FunctionalUtils.computeTrustLine(
+                this.trust,
+                "EC number",
+                "peptide"
+            );
+
+            console.log(this.ecCountTable);
+        }
+        this.calculationsInProgress = false;
+    }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/src/components/analysis/multi/MultiEcSummaryCard.vue
+++ b/src/components/analysis/multi/MultiEcSummaryCard.vue
@@ -73,8 +73,6 @@ export default class MultiEcSummaryCard extends Vue {
     @Watch("searchConfiguration")
     private async recompute() {
         this.calculationsInProgress = true;
-        console.log("peptide count table");
-        console.log(this.peptideCountTable);
         if (this.peptideCountTable) {
             const percentage = parseInt(this.percentSettings);
             const ecCountTableProcessor = new EcCountTableProcessor(
@@ -95,7 +93,6 @@ export default class MultiEcSummaryCard extends Vue {
                 "peptide"
             );
 
-            console.log(this.ecCountTable);
         }
         this.calculationsInProgress = false;
     }

--- a/src/components/analysis/multi/MultiEcSummaryCard.vue
+++ b/src/components/analysis/multi/MultiEcSummaryCard.vue
@@ -8,12 +8,14 @@
         :search-configuration="searchConfiguration"
         :tree="tree"
         :loading="calculationsInProgress"
+        :analysis-in-progress="peptideCountTable"
         :relative-counts="relativeCounts">
         <template v-slot:analysis-header>
             <filter-functional-annotations-dropdown v-model="percentSettings">
             </filter-functional-annotations-dropdown>
             <span>This panel shows the Enzyme Commission numbers that were matched to your peptides. </span>
             <span v-html="trustLine"></span>
+            <span>Click on a row in the table to see a taxonomy tree that highlights occurrences.</span>
         </template>
     </ec-summary-card>
 </template>

--- a/src/components/analysis/multi/MultiGoSummaryCard.vue
+++ b/src/components/analysis/multi/MultiGoSummaryCard.vue
@@ -1,0 +1,162 @@
+<docs>
+    A variant of the GoSummaryCard specifically designed for the analysis of multiple peptides. This variant works
+    with a PeptideCountTable as input and provides the counted GO-terms in function of the amount of peptides associated
+    with it.
+</docs>
+
+<template>
+    <go-summary-card :loading="!peptideCountTable">
+        <template v-slot:analysis-header>
+            <filter-functional-annotations-dropdown v-model="percentSettings">
+            </filter-functional-annotations-dropdown>
+            <span>This panel shows the Gene Ontology annotations that were matched to your peptides. </span>
+            <span v-html="trustLine"></span>
+            <span>Click on a row in a table to see a taxonomy tree that highlights occurrences.</span>
+        </template>
+        <template v-slot:content-biological-process>
+            <go-summary
+                :go-count-table="items[0].countTable"
+                :namespace="namespaces[0]"
+                :go-peptide-mapping="items[0].peptideMapping"
+                :go-ontology="items[0].ontology"
+                :relative-counts="relativeCounts"
+                :search-configuration="searchConfiguration"
+                :show-percentage="showPercentage"
+                :taxa-to-peptides-mapping="taxaToPeptidesMapping"
+                :tree="tree">
+            </go-summary>
+        </template>
+        <template v-slot:content-cellular-component>
+            <go-summary
+                :go-count-table="items[1].countTable"
+                :namespace="namespaces[1]"
+                :go-peptide-mapping="items[1].peptideMapping"
+                :go-ontology="items[1].ontology"
+                :relative-counts="relativeCounts"
+                :search-configuration="searchConfiguration"
+                :show-percentage="showPercentage"
+                :taxa-to-peptides-mapping="taxaToPeptidesMapping"
+                :tree="tree">
+            </go-summary>
+        </template>
+        <template v-slot:content-molecular-function>
+            <go-summary
+                :go-count-table="items[2].countTable"
+                :namespace="namespaces[2]"
+                :go-peptide-mapping="items[2].peptideMapping"
+                :go-ontology="items[2].ontology"
+                :relative-counts="relativeCounts"
+                :search-configuration="searchConfiguration"
+                :show-percentage="showPercentage"
+                :taxa-to-peptides-mapping="taxaToPeptidesMapping"
+                :tree="tree">
+            </go-summary>
+        </template>
+    </go-summary-card>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import Component from "vue-class-component";
+import FilterFunctionalAnnotationsDropdown from "./../functional/FilterFunctionalAnnotationsDropdown.vue";
+import GoSummaryCard from "./../functional/GoSummaryCard.vue";
+import { Prop, Watch } from "vue-property-decorator";
+import { CountTable } from "./../../../business/counts/CountTable";
+import { Peptide } from "./../../../business/ontology/raw/Peptide";
+import SearchConfiguration from "./../../../business/configuration/SearchConfiguration";
+import { NcbiId } from "./../../../business/ontology/taxonomic/ncbi/NcbiTaxon";
+import Tree from "./../../../business/ontology/taxonomic/Tree";
+import GoSummary from "./../functional/GoSummary.vue";
+import GoCountTableProcessor from "./../../../business/processors/functional/go/GoCountTableProcessor";
+import { GoNamespace } from "./../../../business/ontology/functional/go/GoNamespace";
+import GoOntologyProcessor from "./../../../business/ontology/functional/go/GoOntologyProcessor";
+import GoDefinition, { GoCode } from "./../../../business/ontology/functional/go/GoDefinition";
+import { Ontology } from "./../../../business/ontology/Ontology";
+import StringUtils from "./../../../business/misc/StringUtils";
+import { FunctionalUtils } from "./../functional/FunctionalUtils";
+
+@Component({
+    components: {
+        GoSummary,
+        FilterFunctionalAnnotationsDropdown,
+        GoSummaryCard
+    }
+})
+export default class MultiGoSummaryCard extends Vue {
+    @Prop({ required: true })
+    private peptideCountTable: CountTable<Peptide>;
+    @Prop({ required: true })
+    private searchConfiguration: SearchConfiguration;
+    @Prop({ required: true })
+    private relativeCounts: number;
+    @Prop({ required: false, default: false })
+    private showPercentage: boolean;
+    @Prop({ required: false })
+    protected taxaToPeptidesMapping: Map<NcbiId, Peptide[]>;
+    @Prop({ required: false })
+    protected tree: Tree;
+
+    private trustLine: string = "";
+    private calculationsInProgress: boolean = false;
+    private percentSettings: string = "5";
+
+    private namespaces: GoNamespace[] = Object.values(GoNamespace).sort();
+    private items: {
+        countTable: CountTable<GoCode>,
+        peptideMapping: Map<GoCode, Peptide[]>,
+        definitions: GoDefinition[],
+        title: string,
+        ontology: Ontology<GoCode, GoDefinition>
+    }[] = [];
+
+    mounted() {
+        for (let ns of this.namespaces) {
+            this.items.push({
+                countTable: undefined,
+                peptideMapping: undefined,
+                definitions: [],
+                title: StringUtils.stringTitleize(ns.toString()),
+                ontology: undefined
+            });
+        }
+
+        this.recompute();
+    }
+
+    @Watch("peptideCountTable")
+    @Watch("searchConfiguration")
+    @Watch("percentSettings")
+    public async recompute() {
+        this.calculationsInProgress = true;
+        if (this.peptideCountTable) {
+            const percentage = parseInt(this.percentSettings);
+            const goCountTableProcessor = new GoCountTableProcessor(
+                this.peptideCountTable,
+                this.searchConfiguration,
+                percentage
+            );
+
+            for (let i = 0; i < this.namespaces.length; i++) {
+                const namespace: GoNamespace = this.namespaces[i];
+                this.items[i].countTable = await goCountTableProcessor.getCountTable(namespace);
+                this.items[i].peptideMapping = await goCountTableProcessor.getAnnotationPeptideMapping();
+
+                const ontologyProcessor = new GoOntologyProcessor();
+                this.items[i].ontology = await ontologyProcessor.getOntology(this.items[i].countTable);
+
+                this.items[i].definitions.length = 0;
+                this.items[i].definitions.push(
+                    ...this.items[i].countTable.getOntologyIds().map(id => this.items[i].ontology.getDefinition(id))
+                );
+            }
+
+            this.trustLine = FunctionalUtils.computeTrustLine(await goCountTableProcessor.getTrust(), "GO-terms");
+        }
+        this.calculationsInProgress = false;
+    }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/src/components/analysis/multi/MultiGoSummaryCard.vue
+++ b/src/components/analysis/multi/MultiGoSummaryCard.vue
@@ -109,7 +109,7 @@ export default class MultiGoSummaryCard extends Vue {
         ontology: Ontology<GoCode, GoDefinition>
     }[] = [];
 
-    mounted() {
+    created() {
         for (let ns of this.namespaces) {
             this.items.push({
                 countTable: undefined,
@@ -150,7 +150,7 @@ export default class MultiGoSummaryCard extends Vue {
                 );
             }
 
-            this.trustLine = FunctionalUtils.computeTrustLine(await goCountTableProcessor.getTrust(), "GO-terms");
+            this.trustLine = FunctionalUtils.computeTrustLine(await goCountTableProcessor.getTrust(), "GO-term", "peptide");
         }
         this.calculationsInProgress = false;
     }

--- a/src/components/analysis/multi/MultiInterproSummaryCard.vue
+++ b/src/components/analysis/multi/MultiInterproSummaryCard.vue
@@ -1,0 +1,151 @@
+<template>
+    <interpro-summary-card
+        :interpro-count-table="getCountTable"
+        :interpro-ontology="getOntology"
+        :interpro-peptide-mapping="peptideMapping"
+        :analysis-in-progress="peptideCountTable"
+        :search-configuration="searchConfiguration"
+        :loading="loading"
+        :relative-counts="relativeCounts"
+        :show-percentage="showPercentage"
+        :taxa-to-peptides-mapping="taxaToPeptidesMapping"
+        :tree="tree">
+        <template v-slot:analysis-header>
+            <filter-functional-annotations-dropdown v-model="percentSettings">
+            </filter-functional-annotations-dropdown>
+            <span>This panel shows the Interpro entries that were matched to your peptides. </span>
+            <span v-html="trustLine"></span>
+            <span>Click on a row in the table to see a taxonomy tree that highlights occurrences.</span>
+        </template>
+    </interpro-summary-card>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import Component from "vue-class-component";
+import InterproSummaryCard from "./../functional/InterproSummaryCard.vue";
+import FilterFunctionalAnnotationsDropdown from "./../functional/FilterFunctionalAnnotationsDropdown.vue";
+import { Prop, Watch } from "vue-property-decorator";
+import { Peptide } from "./../../../business/ontology/raw/Peptide";
+import { CountTable } from "./../../../business/counts/CountTable";
+import InterproDefinition, { InterproCode } from "./../../../business/ontology/functional/interpro/InterproDefinition";
+import { Ontology } from "./../../../business/ontology/Ontology";
+import InterproCountTableProcessor from "./../../../business/processors/functional/interpro/InterproCountTableProcessor";
+import {
+    convertStringToInterproNamespace,
+    InterproNamespace
+} from "./../../../business/ontology/functional/interpro/InterproNamespace";
+import InterproOntologyProcessor from "./../../../business/ontology/functional/interpro/InterproOntologyProcessor";
+import SearchConfiguration from "./../../../business/configuration/SearchConfiguration";
+import { NcbiId } from "./../../../business/ontology/taxonomic/ncbi/NcbiTaxon";
+import Tree from "./../../../business/ontology/taxonomic/Tree";
+import { FunctionalUtils } from "./../../../components/analysis/functional/FunctionalUtils";
+
+@Component({
+    components: { InterproSummaryCard, FilterFunctionalAnnotationsDropdown }
+})
+export default class MultiInterproSummaryCard extends Vue {
+    @Prop({ required: true })
+    private peptideCountTable: CountTable<Peptide>;
+    @Prop({ required: true })
+    private searchConfiguration: SearchConfiguration;
+    @Prop({ required: true })
+    private relativeCounts: number;
+    @Prop({ required: false, default: false })
+    private showPercentage: boolean;
+    @Prop({ required: false })
+    protected taxaToPeptidesMapping: Map<NcbiId, Peptide[]>;
+    @Prop({ required: false })
+    protected tree: Tree;
+
+    private trustLine: string = "";
+    private loading: boolean = false;
+
+    private percentSettings: string = "5";
+
+    private namespaceValues: string[] = ["all"].concat(Object.values(InterproNamespace));
+
+    private items: {
+        countTable: CountTable<InterproCode>,
+        definitions: InterproDefinition[],
+        title: string,
+        namespace: string
+        ontology: Ontology<InterproCode, InterproDefinition>
+    }[] = [];
+    private peptideMapping: Map<InterproCode, Peptide[]> = null;
+
+    private created() {
+        for (const ns of this.namespaceValues) {
+            this.items.push({
+                countTable: undefined,
+                definitions: [],
+                title: "",
+                namespace: ns,
+                ontology: undefined
+            });
+        }
+    }
+
+    private mounted() {
+        this.recompute();
+    }
+
+    @Watch("peptideCountTable")
+    @Watch("searchConfiguration")
+    public async recompute(): Promise<void> {
+        if (this.peptideCountTable && this.searchConfiguration) {
+            this.loading = true;
+            const percentage = parseInt(this.percentSettings);
+            const interproProcessor = new InterproCountTableProcessor(
+                this.peptideCountTable,
+                this.searchConfiguration,
+                percentage
+            );
+
+            this.peptideMapping = await interproProcessor.getAnnotationPeptideMapping();
+
+
+            for (const [i, ns] of this.namespaceValues.entries()) {
+                let countTable: CountTable<InterproCode>;
+
+                if (ns === "all") {
+                    countTable = await interproProcessor.getCountTable();
+                } else {
+                    countTable = await interproProcessor.getCountTable(ns as InterproNamespace);
+                }
+
+                this.items[i].countTable = countTable;
+
+                const ontologyProcessor = new InterproOntologyProcessor();
+                this.items[i].ontology = await ontologyProcessor.getOntology(this.items[i].countTable);
+
+                this.items[i].definitions.length = 0;
+                this.items[i].definitions.push(
+                    ...this.items[i].countTable.getOntologyIds().map(id => this.items[i].ontology.getDefinition(id))
+                );
+            }
+
+            this.trustLine = FunctionalUtils.computeTrustLine(
+                await interproProcessor.getTrust(),
+                "InterPro-entry",
+                "peptide"
+            );
+            this.loading = false;
+        }
+    }
+
+    private getCountTable(ns: string): CountTable<InterproCode> {
+        const item = this.items.find(item => item.namespace == ns);
+        return item ? item.countTable : undefined;
+    }
+
+    private getOntology(ns: string): Ontology<InterproCode, InterproDefinition> {
+        const item = this.items.find(item => item.namespace == ns);
+        return item ? item.ontology : undefined;
+    }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/src/components/analysis/single/SingleEcSummaryCard.vue
+++ b/src/components/analysis/single/SingleEcSummaryCard.vue
@@ -1,0 +1,81 @@
+<docs>
+    A variant of the EcSummaryCard that's specifically designed for the analysis of a single peptide. This variant works
+    with a peptide as input and provides the counted EC-numbers in function of the amount of proteins associated with
+    it.
+</docs>
+
+<template>
+    <ec-summary-card
+        :loading="loading"
+        :ec-count-table="countTable"
+        :ec-ontology="ontology"
+        :relative-counts="trust ? trust.totalAmountOfItems : 1"
+        :show-percentage="false">
+        <template v-slot:analysis-header>
+            <span v-html="trustLine"></span>
+        </template>
+    </ec-summary-card>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import Component from "vue-class-component";
+import EcSummaryCard from "./../functional/EcSummaryCard.vue";
+import { Peptide } from "./../../../business/ontology/raw/Peptide";
+import { Prop, Watch } from "vue-property-decorator";
+import EcDefinition, { EcCode } from "./../../../business/ontology/functional/ec/EcDefinition";
+import { CountTable } from "./../../../business/counts/CountTable";
+import { Ontology } from "./../../../business/ontology/Ontology";
+import EcProteinCountTableProcessor from "./../../../business/processors/functional/ec/EcProteinCountTableProcessor";
+import EcOntologyProcessor from "./../../../business/ontology/functional/ec/EcOntologyProcessor";
+import FunctionalTrust from "./../../../business/processors/functional/FunctionalTrust";
+import { FunctionalUtils } from "./../functional/FunctionalUtils";
+
+@Component({
+    components: { EcSummaryCard }
+})
+export default class SingleEcSummaryCard extends Vue {
+    @Prop({ required: true })
+    private peptide: Peptide;
+    @Prop({ required: true })
+    private equateIl: boolean;
+
+    private trust: FunctionalTrust = null;
+    private trustLine: string = "";
+    private loading: boolean = false;
+
+    private countTable: CountTable<EcCode> = null;
+    private ontology: Ontology<EcCode, EcDefinition> = null;
+
+    private mounted() {
+        this.onInputsChanged();
+    }
+
+    @Watch("peptide")
+    @Watch("equateIl")
+    private async onInputsChanged() {
+        if (this.peptide) {
+            this.loading = true;
+
+            const ecProteinProcessor = new EcProteinCountTableProcessor(this.peptide, this.equateIl);
+            this.countTable = await ecProteinProcessor.getCountTable();
+
+            console.log(this.countTable);
+
+            const ontologyProcessor = new EcOntologyProcessor();
+            this.ontology = await ontologyProcessor.getOntology(this.countTable);
+
+            console.log(this.ontology);
+
+            this.trust = await ecProteinProcessor.getTrust();
+            this.trustLine = FunctionalUtils.computeTrustLine(this.trust, "EC-number", "protein");
+
+            this.loading = false;
+        }
+    }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/src/components/analysis/single/SingleEcSummaryCard.vue
+++ b/src/components/analysis/single/SingleEcSummaryCard.vue
@@ -7,12 +7,13 @@
 <template>
     <ec-summary-card
         :loading="loading"
+        :analysis-in-progress="true"
         :ec-count-table="countTable"
         :ec-ontology="ontology"
         :relative-counts="trust ? trust.totalAmountOfItems : 1"
         :show-percentage="false">
         <template v-slot:analysis-header>
-            <span v-html="trustLine"></span>
+            <span v-html="trustLine" class="ec-trust"></span>
         </template>
     </ec-summary-card>
 </template>

--- a/src/components/analysis/single/SingleEcSummaryCard.vue
+++ b/src/components/analysis/single/SingleEcSummaryCard.vue
@@ -60,12 +60,8 @@ export default class SingleEcSummaryCard extends Vue {
             const ecProteinProcessor = new EcProteinCountTableProcessor(this.peptide, this.equateIl);
             this.countTable = await ecProteinProcessor.getCountTable();
 
-            console.log(this.countTable);
-
             const ontologyProcessor = new EcOntologyProcessor();
             this.ontology = await ontologyProcessor.getOntology(this.countTable);
-
-            console.log(this.ontology);
 
             this.trust = await ecProteinProcessor.getTrust();
             this.trustLine = FunctionalUtils.computeTrustLine(this.trust, "EC-number", "protein");

--- a/src/components/analysis/single/SingleGoSummaryCard.vue
+++ b/src/components/analysis/single/SingleGoSummaryCard.vue
@@ -1,0 +1,134 @@
+<docs>
+    A variant of the GoSummaryCard that's specifically designed for the analysis of a single peptide. This variant works
+    with a peptide as input and provides the counted GO-terms in function of the amount of proteins associated with it.
+</docs>
+
+<template>
+    <go-summary-card :loading="peptide === ''">
+        <template v-slot:analysis-header>
+            <span v-html="trustLine"></span>
+        </template>
+        <template v-slot:content-biological-process>
+            <go-summary
+                :go-count-table="items[0].countTable"
+                :namespace="namespaces[0]"
+                :go-ontology="items[0].ontology"
+                :relative-counts="trust ? trust.totalAmountOfItems : 1"
+                :loading="loading"
+                :show-percentage="false">
+            </go-summary>
+        </template>
+        <template v-slot:content-cellular-component>
+            <go-summary
+                :go-count-table="items[1].countTable"
+                :namespace="namespaces[1]"
+                :go-ontology="items[1].ontology"
+                :relative-counts="trust ? trust.totalAmountOfItems : 1"
+                :loading="loading"
+                :show-percentage="false">
+            </go-summary>
+        </template>
+        <template v-slot:content-molecular-function>
+            <go-summary
+                :go-count-table="items[2].countTable"
+                :namespace="namespaces[2]"
+                :go-ontology="items[2].ontology"
+                :relative-counts="trust ? trust.totalAmountOfItems : 1"
+                :loading="loading"
+                :show-percentage="false">
+            </go-summary>
+        </template>
+    </go-summary-card>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import Component from "vue-class-component";
+import { Prop, Watch } from "vue-property-decorator";
+import { Peptide } from "./../../../business/ontology/raw/Peptide";
+import { GoNamespace } from "./../../../business/ontology/functional/go/GoNamespace";
+import { CountTable } from "./../../../business/counts/CountTable";
+import GoDefinition, { GoCode } from "./../../../business/ontology/functional/go/GoDefinition";
+import { Ontology } from "./../../../business/ontology/Ontology";
+import StringUtils from "./../../../business/misc/StringUtils";
+import GoProteinCountTableProcessor from "./../../../business/processors/functional/go/GoProteinCountTableProcessor";
+import GoOntologyProcessor from "./../../../business/ontology/functional/go/GoOntologyProcessor";
+import { FunctionalUtils } from "./../functional/FunctionalUtils";
+import GoSummaryCard from "./../functional/GoSummaryCard.vue";
+import GoSummary from "./../functional/GoSummary.vue";
+import FunctionalTrust from "./../../../business/processors/functional/FunctionalTrust";
+
+@Component({
+    components: {
+        GoSummary,
+        GoSummaryCard
+    }
+})
+export default class SingleGoSummaryCard extends Vue {
+    @Prop({ required: true })
+    private peptide: Peptide;
+    @Prop({ required: true })
+    private equateIl: boolean;
+
+    private trust: FunctionalTrust = null;
+    private trustLine: string = "";
+    private loading: boolean = false;
+
+    private namespaces: GoNamespace[] = Object.values(GoNamespace).sort();
+    private items: {
+        countTable: CountTable<GoCode>,
+        definitions: GoDefinition[],
+        title: string,
+        ontology: Ontology<GoCode, GoDefinition>
+    }[] = [];
+
+    private created() {
+        for (let ns of this.namespaces) {
+            this.items.push({
+                countTable: undefined,
+                definitions: [],
+                title: StringUtils.stringTitleize(ns.toString()),
+                ontology: undefined
+            });
+        }
+    }
+
+    private mounted() {
+        this.recompute();
+    }
+
+    @Watch("peptide")
+    @Watch("equateIl")
+    private async recompute() {
+        if (this.peptide) {
+            this.loading = true;
+
+            const goProteinProcessor = new GoProteinCountTableProcessor(this.peptide, this.equateIl);
+
+            for (let i = 0; i < this.namespaces.length; i++) {
+                const namespace: GoNamespace = this.namespaces[i];
+                this.items[i].countTable = await goProteinProcessor.getCountTable(namespace);
+
+                const ontologyProcessor = new GoOntologyProcessor();
+                this.items[i].ontology = await ontologyProcessor.getOntology(this.items[i].countTable);
+
+                this.items[i].definitions.length = 0;
+                this.items[i].definitions.push(
+                    ...this.items[i].countTable.getOntologyIds().map(id => this.items[i].ontology.getDefinition(id))
+                );
+            }
+
+            console.log(this.items);
+
+            this.trust = await goProteinProcessor.getTrust();
+            this.trustLine = FunctionalUtils.computeTrustLine(this.trust, "GO-term", "protein");
+
+            this.loading = false;
+        }
+    }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/src/components/analysis/single/SingleGoSummaryCard.vue
+++ b/src/components/analysis/single/SingleGoSummaryCard.vue
@@ -6,7 +6,7 @@
 <template>
     <go-summary-card :loading="peptide === ''">
         <template v-slot:analysis-header>
-            <span v-html="trustLine"></span>
+            <span v-html="trustLine" class="go-trust"></span>
         </template>
         <template v-slot:content-biological-process>
             <go-summary
@@ -103,7 +103,6 @@ export default class SingleGoSummaryCard extends Vue {
         if (this.peptide) {
             this.loading = true;
 
-            console.log("blabla");
             const goProteinProcessor = new GoProteinCountTableProcessor(this.peptide, this.equateIl);
 
             for (let i = 0; i < this.namespaces.length; i++) {

--- a/src/components/analysis/single/SingleGoSummaryCard.vue
+++ b/src/components/analysis/single/SingleGoSummaryCard.vue
@@ -103,6 +103,7 @@ export default class SingleGoSummaryCard extends Vue {
         if (this.peptide) {
             this.loading = true;
 
+            console.log("blabla");
             const goProteinProcessor = new GoProteinCountTableProcessor(this.peptide, this.equateIl);
 
             for (let i = 0; i < this.namespaces.length; i++) {
@@ -117,8 +118,6 @@ export default class SingleGoSummaryCard extends Vue {
                     ...this.items[i].countTable.getOntologyIds().map(id => this.items[i].ontology.getDefinition(id))
                 );
             }
-
-            console.log(this.items);
 
             this.trust = await goProteinProcessor.getTrust();
             this.trustLine = FunctionalUtils.computeTrustLine(this.trust, "GO-term", "protein");

--- a/src/components/analysis/single/SingleInterproSummaryCard.vue
+++ b/src/components/analysis/single/SingleInterproSummaryCard.vue
@@ -10,7 +10,7 @@
         :relative-counts="trust ? trust.totalAmountOfItems : 1"
         :show-percentage="false">
         <template v-slot:analysis-header>
-            <span v-html="trustLine"></span>
+            <span v-html="trustLine" class="interpro-trust"></span>
         </template>
     </interpro-summary-card>
 </template>
@@ -96,7 +96,7 @@ export default class SingleInterproSummaryCard extends Vue {
             this.trustLine = FunctionalUtils.computeTrustLine(
                 this.trust,
                 "InterPro-entry",
-                "peptide"
+                "protein"
             );
 
             this.loading = false;

--- a/src/components/analysis/single/__tests__/SingleEcSummaryCard.spec.ts
+++ b/src/components/analysis/single/__tests__/SingleEcSummaryCard.spec.ts
@@ -1,0 +1,72 @@
+import Vue from "vue"
+import Vuetify from "vuetify"
+import { createLocalVue, mount } from "@vue/test-utils";
+import { waitForCondition, waitForElement } from "@/test/Utils";
+import Setup from "@/test/Setup";
+import SingleEcSummaryCard from "@/components/analysis/single/SingleEcSummaryCard.vue";
+
+Vue.use(Vuetify);
+
+const localVue = createLocalVue();
+
+describe("SingleEcSummaryCard", () => {
+    let vuetify;
+
+    beforeEach(() => {
+        vuetify = new Vuetify();
+    });
+
+    beforeAll(() => {
+        const setup = new Setup();
+        setup.setupAll();
+    });
+
+    it("correctly displays the correct EC-entries for a given peptide", async() => {
+        const wrapper = mount(SingleEcSummaryCard, {
+            localVue,
+            vuetify,
+            propsData: {
+                peptide: "AALTER",
+                equateIl: true
+            },
+            sync: false
+        });
+
+        await wrapper.vm.$nextTick();
+
+        // Wait for the table to be rendered.
+        await waitForCondition(() => wrapper.findAll("tr").length > 1);
+
+        // We sort the proteins by code, to make the test deterministic
+        const sortButton = wrapper.findAll("th").filter(w => w.html().includes("EC number")).at(0);
+        sortButton.trigger("click");
+
+        // Wait for this element to be the first in the table, which means sorting is done
+        await waitForCondition(() => wrapper.find("tbody tr").html().includes("EC:2.3.2.27"));
+
+        const trs = wrapper.findAll("tbody tr");
+        expect(trs.at(0).html().includes("EC:2.3.2.27")).toBeTruthy();
+        expect(trs.at(1).html().includes("EC:5.6.2.1")).toBeTruthy();
+
+        expect(wrapper.find(".v-data-footer__pagination").text()).toEqual("1-2 of 2");
+    });
+
+    it("displays the correct trust line", async() => {
+        const wrapper = mount(SingleEcSummaryCard, {
+            localVue,
+            vuetify,
+            propsData: {
+                peptide: "AALTER",
+                equateIl: true
+            },
+            sync: false
+        });
+
+        await wrapper.vm.$nextTick();
+
+        // Wait for the table to be rendered.
+        await waitForCondition(() => wrapper.findAll("tr").length > 1);
+
+        expect(wrapper.find(".ec-trust")).toMatchSnapshot();
+    });
+});

--- a/src/components/analysis/single/__tests__/SingleGoSummaryCard.spec.ts
+++ b/src/components/analysis/single/__tests__/SingleGoSummaryCard.spec.ts
@@ -1,0 +1,91 @@
+import Vue from "vue"
+import Vuetify from "vuetify"
+import { createLocalVue, mount } from "@vue/test-utils";
+import Setup from "@/test/Setup";
+import { waitForCondition } from "@/test/Utils";
+import SingleGoSummaryCard from "@/components/analysis/single/SingleGoSummaryCard.vue";
+
+Vue.use(Vuetify);
+
+const localVue = createLocalVue();
+
+describe("SingleGoSummaryCard", () => {
+    let vuetify;
+
+    beforeEach(() => {
+        vuetify = new Vuetify();
+    });
+
+    beforeAll(() => {
+        const setup = new Setup();
+        setup.setupAll();
+    });
+
+    it("correctly displays the correct GO-terms for a given peptide", async() => {
+        const wrapper = mount(SingleGoSummaryCard, {
+            localVue,
+            vuetify,
+            propsData: {
+                peptide: "AALTER",
+                equateIl: true
+            },
+            sync: false
+        });
+
+        await waitForCondition(() => wrapper.findAll("tr").length > 1);
+
+        const sortButtons = wrapper.findAll("th").filter(w => w.html().includes("GO term"));
+        // Filter each of the 3 tables by GO-term code.
+        sortButtons.wrappers.map(w => w.trigger("click"));
+
+        // This should include 3 containers. The first one for biological process, the second one for cellular
+        // component and the last one for molecular function.
+        const goContainers = wrapper.findAll(".go-table-container");
+
+        // Make sure each of these containers has been sorted correctly before continuing
+        await waitForCondition(() => goContainers.at(0).find("tbody tr").html().includes("GO:0000746"));
+        await waitForCondition(() => goContainers.at(1).find("tbody tr").html().includes("GO:0005634"));
+        await waitForCondition(() => goContainers.at(2).find("tbody tr").html().includes("GO:0000287"));
+
+        // Now check for each of the tables if it contains the expected GO-terms.
+        let trs = goContainers.at(0).findAll("tbody tr");
+        expect(trs.at(0).html().includes("GO:0000746")).toBeTruthy();
+        expect(trs.at(1).html().includes("GO:0008152")).toBeTruthy();
+        expect(trs.at(2).html().includes("GO:0016567")).toBeTruthy();
+
+        expect(goContainers.at(0).find(".v-data-footer__pagination").text()).toEqual("1-3 of 3");
+
+        // Tests for cellular component
+        trs = goContainers.at(1).findAll("tbody tr");
+        expect(trs.at(0).html().includes("GO:0005634")).toBeTruthy();
+        expect(trs.at(1).html().includes("GO:0005737")).toBeTruthy();
+        expect(trs.at(2).html().includes("GO:0005829")).toBeTruthy();
+
+        expect(goContainers.at(1).find(".v-data-footer__pagination").text()).toEqual("1-3 of 3");
+
+        // Tests for molecular function
+        trs = goContainers.at(2).findAll("tbody tr");
+        expect(trs.at(0).html().includes("GO:0000287")).toBeTruthy();
+        expect(trs.at(1).html().includes("GO:0003677")).toBeTruthy();
+        expect(trs.at(2).html().includes("GO:0003678")).toBeTruthy();
+
+        expect(goContainers.at(2).find(".v-data-footer__pagination").text()).toEqual("1-5 of 10");
+    });
+
+    it("displays the correct trust line", async() => {
+        const wrapper = mount(SingleGoSummaryCard, {
+            localVue,
+            vuetify,
+            propsData: {
+                peptide: "AALTER",
+                equateIl: true
+            },
+            sync: false
+        });
+
+        // Wait for the table to be rendered.
+        await waitForCondition(() => wrapper.find(".go-trust").html().includes("protein"));
+
+        expect(wrapper.find(".go-trust").html()).toMatchSnapshot();
+    });
+});

--- a/src/components/analysis/single/__tests__/SingleInterproSummaryCard.spec.ts
+++ b/src/components/analysis/single/__tests__/SingleInterproSummaryCard.spec.ts
@@ -1,0 +1,71 @@
+import Setup from "@/test/Setup";
+import Vue from "vue"
+import Vuetify from "vuetify"
+import { createLocalVue, mount } from "@vue/test-utils";
+import { waitForCondition, waitForElement } from "@/test/Utils";
+import SingleInterproSummaryCard from "@/components/analysis/single/SingleInterproSummaryCard.vue";
+
+Vue.use(Vuetify);
+
+const localVue = createLocalVue();
+
+describe("SingleInterproSummaryCard", () => {
+    let vuetify;
+
+    beforeEach(() => {
+        vuetify = new Vuetify();
+    });
+
+    beforeAll(() => {
+        const setup = new Setup();
+        setup.setupAll();
+    });
+
+    it("correctly displays the correct InterPro-entries for a given peptide", async() => {
+        const wrapper = mount(SingleInterproSummaryCard, {
+            localVue,
+            vuetify,
+            propsData: {
+                peptide: "AALTER",
+                equateIl: true
+            },
+            sync: false
+        });
+
+        // Wait for the table to be rendered.
+        await waitForCondition(() => wrapper.findAll(".tr").length > 1);
+
+        // We sort the proteins by code, to make the test deterministic
+        const sortButton = wrapper.findAll("th").filter(w => w.html().includes("Interpro entry")).at(0);
+        sortButton.trigger("click");
+
+        // Wait for this element to be the first in the table, which means sorting is done
+        await waitForCondition(() => wrapper.find("tbody tr").html().includes("IPR042201"));
+
+        // We know that the following IPR-entries are associated with the AALTER peptide, and should thus be present.
+        const trs = wrapper.findAll("tbody tr");
+        expect(trs.at(0).html().includes("IPR000225")).toBeTruthy();
+        expect(trs.at(1).html().includes("IPR003613")).toBeTruthy();
+        expect(trs.at(2).html().includes("IPR009767")).toBeTruthy();
+
+        // Make sure the total count of items is correct.
+        expect(wrapper.find(".v-data-footer__pagination").text()).toEqual("1-9 of 9");
+    });
+
+    it("displays the correct trust line", async() => {
+        const wrapper = mount(SingleInterproSummaryCard, {
+            localVue,
+            vuetify,
+            propsData: {
+                peptide: "AALTER",
+                equateIl: true
+            },
+            sync: false
+        });
+
+        // Wait for the table to be rendered.
+        await waitForCondition(() => wrapper.findAll(".tr").length > 1);
+
+        expect(wrapper.find(".interpro-trust").html()).toMatchSnapshot();
+    });
+});

--- a/src/components/analysis/single/__tests__/SingleInterproSummaryCard.spec.ts
+++ b/src/components/analysis/single/__tests__/SingleInterproSummaryCard.spec.ts
@@ -33,7 +33,7 @@ describe("SingleInterproSummaryCard", () => {
         });
 
         // Wait for the table to be rendered.
-        await waitForCondition(() => wrapper.findAll(".tr").length > 1);
+        await waitForCondition(() => wrapper.findAll("tr").length > 1);
 
         // We sort the proteins by code, to make the test deterministic
         const sortButton = wrapper.findAll("th").filter(w => w.html().includes("Interpro entry")).at(0);
@@ -64,7 +64,7 @@ describe("SingleInterproSummaryCard", () => {
         });
 
         // Wait for the table to be rendered.
-        await waitForCondition(() => wrapper.findAll(".tr").length > 1);
+        await waitForCondition(() => wrapper.findAll("tr").length > 1);
 
         expect(wrapper.find(".interpro-trust").html()).toMatchSnapshot();
     });

--- a/src/components/analysis/single/__tests__/__snapshots__/SingleEcSummaryCard.spec.ts.snap
+++ b/src/components/analysis/single/__tests__/__snapshots__/SingleEcSummaryCard.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SingleEcSummaryCard displays the correct trust line 1`] = `Wrapper {}`;

--- a/src/components/analysis/single/__tests__/__snapshots__/SingleGoSummaryCard.spec.ts.snap
+++ b/src/components/analysis/single/__tests__/__snapshots__/SingleGoSummaryCard.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SingleGoSummaryCard displays the correct trust line 1`] = `"<span class=\\"go-trust\\"><strong>All proteins</strong> have at least one GO-term assigned to them. </span>"`;

--- a/src/components/analysis/single/__tests__/__snapshots__/SingleInterproSummaryCard.spec.ts.snap
+++ b/src/components/analysis/single/__tests__/__snapshots__/SingleInterproSummaryCard.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SingleInterproSummaryCard displays the correct trust line 1`] = `"<span class=\\"interpro-trust\\"><strong>All proteins</strong> have at least one InterPro-entry assigned to them. </span>"`;

--- a/src/components/tables/AmountTable.vue
+++ b/src/components/tables/AmountTable.vue
@@ -4,7 +4,7 @@
             :headers="tableHeaders"
             :loading="loading"
             :items="items"
-            :items-per-page="5"
+            :items-per-page="rowsPerPage"
             item-key="code"
             :show-expand="itemToPeptidesMapping"
             :expanded.sync="expandedItemsList">
@@ -170,6 +170,8 @@ export default class AmountTable extends Vue {
     protected loading: boolean;
     @Prop({ required: false, default: false })
     protected showPercentage: boolean;
+    @Prop({ required: false, default: 5 })
+    private rowsPerPage: number;
 
     protected treeAvailable = new Map<TableItem, TreeNode>();
 

--- a/src/components/tables/AmountTable.vue
+++ b/src/components/tables/AmountTable.vue
@@ -9,7 +9,7 @@
             :show-expand="itemToPeptidesMapping"
             :expanded.sync="expandedItemsList">
             <template v-slot:top>
-                <v-tooltip :open-delay=1000 bottom>
+                <v-tooltip bottom>
                     <template v-slot:activator="{ on }">
                         <v-icon @click="saveTableAsCsv()" class="table-to-csv-button" v-on="on">mdi-download</v-icon>
                     </template>
@@ -100,6 +100,13 @@ import { NcbiId } from "./../../business/ontology/taxonomic/ncbi/NcbiTaxon";
         tableHeaders: function() {
             const headers = [
                 {
+                    text: "",
+                    align: "left",
+                    value: "",
+                    width: "5%",
+                    sortable: false
+                },
+                {
                     text: this.countName + (this.showPercentage ? " %" : ""),
                     align: "left",
                     value: "count",
@@ -108,7 +115,7 @@ import { NcbiId } from "./../../business/ontology/taxonomic/ncbi/NcbiTaxon";
                     text: this.annotationName,
                     align: "left",
                     value: "code",
-                    width: this.itemsToPeptideMapping ? "30%" : "35%"
+                    width: this.itemsToPeptideMapping ? "25%" : "30%"
                 }, {
                     text: "Name",
                     align: "left",

--- a/src/components/tables/AmountTable.vue
+++ b/src/components/tables/AmountTable.vue
@@ -6,7 +6,7 @@
             :items="items"
             :items-per-page="5"
             item-key="code"
-            show-expand
+            :show-expand="itemToPeptidesMapping"
             :expanded.sync="expandedItemsList">
             <template v-slot:top>
                 <v-tooltip :open-delay=1000 bottom>
@@ -16,7 +16,8 @@
                     <span>Download table as CSV</span>
                 </v-tooltip>
             </template>
-            <template v-slot:expanded-item="{ headers, item }">
+            <!-- We can only process the tree when a mapping between items and peptides is given -->
+            <template v-slot:expanded-item="{ headers, item }" v-if="this.itemToPeptidesMapping">
                 <td class="item-treeview" :colspan="headers.length">
                     <div v-if="tree && (treeAvailable.get(item) || computeTree(item))">
                         <v-btn small depressed class="item-treeview-dl-btn" @click="saveImage(item)">
@@ -47,7 +48,7 @@
                     {{ showPercentage ? (item.relativeCount * 100).toFixed(2) + " %" : item.count }}
                 </div>
             </template>
-            <template v-slot:Name="{ item }">
+            <template v-slot:item.name="{ item }">
                 <span style="text-overflow: ellipsis;">
                      {{ item.name }}
                 </span>
@@ -97,28 +98,35 @@ import { NcbiId } from "./../../business/ontology/taxonomic/ncbi/NcbiTaxon";
     computed:
     {
         tableHeaders: function() {
-            return [{
-                text: "Peptides" + (this.showPercentage ? " %" : ""),
-                align: "left",
-                value: "count",
-                width: "20%"
-            }, {
-                text: this.annotationName,
-                align: "left",
-                value: "code",
-                width: "30%"
-            }, {
-                text: "Name",
-                align: "left",
-                value: "name",
-                width: "40%"
-            }, {
-                text: "Actions",
-                align: "center",
-                width: "15%",
-                sortable: false,
-                value: "action"
-            }]
+            const headers = [
+                {
+                    text: this.countName + (this.showPercentage ? " %" : ""),
+                    align: "left",
+                    value: "count",
+                    width: "20%"
+                }, {
+                    text: this.annotationName,
+                    align: "left",
+                    value: "code",
+                    width: this.itemsToPeptideMapping ? "30%" : "35%"
+                }, {
+                    text: "Name",
+                    align: "left",
+                    value: "name",
+                    width: this.itemsToPeptideMapping ? "30%" : "45%"
+                }
+            ];
+
+            if (this.itemsToPeptideMapping) {
+                headers.push({
+                    text: "Actions",
+                    align: "center",
+                    width: "15%",
+                    value: "action"
+                });
+            }
+
+            return headers;
         }
     }
 })
@@ -132,12 +140,21 @@ export default class AmountTable extends Vue {
     @Prop({ required: true })
     protected annotationName: string;
 
+    /**
+     * What items are displayed as counts? (e.g. peptides, proteins, ...)
+     */
+    @Prop({ required: false, default: "Peptides" })
+    protected countName: string;
     @Prop({ required: false })
     protected namespace: string;
     @Prop({ required: false })
     protected searchConfiguration: SearchConfiguration;
     @Prop({ required: false })
     protected tree: Tree;
+    /**
+     * A map that returns for a given annotation all peptides associated with this annotation. If this map is not
+     * given, then no TreeView will be rendered and no expandable rows will be present.
+     */
     @Prop({ required: false })
     protected itemToPeptidesMapping: Map<string, Peptide[]>;
     @Prop({ required: false })

--- a/src/components/tables/EcAmountTable.vue
+++ b/src/components/tables/EcAmountTable.vue
@@ -85,17 +85,19 @@ export default class EcAmountTable extends Vue {
                 const definition: EcDefinition = this.ecOntology.getDefinition(ecCode);
                 const currentCount = this.ecCountTable.getCounts(ecCode);
 
-                return new TableItem(
-                    currentCount,
-                    currentCount / this.relativeCounts,
-                    definition.name,
-                    definition.code,
-                    definition
-                );
+                if (definition) {
+                    return new TableItem(
+                        currentCount,
+                        currentCount / this.relativeCounts,
+                        definition.name,
+                        definition.code,
+                        definition
+                    );
+                }
             });
 
             this.items.length = 0;
-            this.items.push(...newItems.sort((a: TableItem, b: TableItem) => b.count - a.count));
+            this.items.push(...newItems.filter(i => i).sort((a: TableItem, b: TableItem) => b.count - a.count));
 
             this.computeInProgress = false;
         }

--- a/src/components/tables/InterproAmountTable.vue
+++ b/src/components/tables/InterproAmountTable.vue
@@ -2,6 +2,7 @@
     <amount-table
         :items="items"
         :loading="isLoading"
+        :rows-per-page="10"
         annotation-name="Interpro entry"
         :search-configuration="searchConfiguration"
         :item-to-peptides-mapping="interproPeptideMapping"

--- a/src/components/visualizations/Treeview.vue
+++ b/src/components/visualizations/Treeview.vue
@@ -88,9 +88,11 @@ export default class Treeview extends Vue {
                 this.treeview = $(this.$refs.visualization).html("").treeview(JSON.parse(JSON.stringify(this.data)), settings);
 
                 if (this.autoResize) {
-                    let svgEl = (this.$refs.visualization as HTMLElement).querySelector("svg")
-                    svgEl.setAttribute("height", "100%")
-                    svgEl.setAttribute("width", "100%")
+                    let svgEl = (this.$refs.visualization as HTMLElement).querySelector("svg");
+                    if (svgEl) {
+                        svgEl.setAttribute("height", "100%");
+                        svgEl.setAttribute("width", "100%");
+                    }
                 }
             }
 

--- a/src/test/Setup.ts
+++ b/src/test/Setup.ts
@@ -5,6 +5,7 @@ import ClipboardMock from "./ClipboardMock";
 import NetworkConfiguration from "@/business/communication/NetworkConfiguration";
 import UnipeptApiDataSource from "@/test/api/UnipeptApiDataSource";
 const fetchPolyfill = require("whatwg-fetch")
+import $ from "@/test/mocks/jQuery";
 
 export default class Setup {
     public setupAll() {
@@ -13,6 +14,7 @@ export default class Setup {
         this.setupUnipeptNock();
         this.setUpPrideNock();
         this.setupClipboard();
+        this.setupJQuery();
     }
 
     public setupLocalStorage() {
@@ -21,6 +23,11 @@ export default class Setup {
 
     public setupFetch() {
         globalThis.fetch = fetchPolyfill.fetch;
+    }
+
+    public setupJQuery() {
+        // @ts-ignore
+        globalThis["$"] = $;
     }
 
     public setupClipboard() {

--- a/src/test/api/resources/unipept/ecnumbers.json
+++ b/src/test/api/resources/unipept/ecnumbers.json
@@ -162,5 +162,33 @@
   {
     "code": "7.1.1.-",
     "name": "Hydron translocation or charge separation linked to oxidoreductase reactions"
+  },
+  {
+    "code": "2.3.-.-",
+    "name": "Acyltransferases"
+  },
+  {
+    "code": "2.3.2.-",
+    "name": "Aminoacyltransferases"
+  },
+  {
+    "code": "2.3.2.27",
+    "name": "RING-type E3 ubiquitin transferase"
+  },
+  {
+    "code": "5.-.-.-",
+    "name": "Isomerases"
+  },
+  {
+    "code": "5.6.-.-",
+    "name": "Isomerases altering macromolecular conformation"
+  },
+  {
+    "code": "5.6.2.-",
+    "name": "Enzymes altering nucleic acid conformation"
+  },
+  {
+    "code": "5.6.2.1",
+    "name": "DNA topoisomerase"
   }
 ]

--- a/src/test/api/resources/unipept/goterms.json
+++ b/src/test/api/resources/unipept/goterms.json
@@ -1028,5 +1028,65 @@
     "code": "GO:2001234",
     "name": "negative regulation of apoptotic signaling pathway",
     "namespace": "biological process"
+  },
+  {
+    "code": "GO:0000746",
+    "name": "conjugation",
+    "namespace": "biological process"
+  },
+  {
+    "code": "GO:0003677",
+    "name": "DNA binding",
+    "namespace": "molecular function"
+  },
+  {
+    "code": "GO:0003678",
+    "name": "DNA helicase activity",
+    "namespace": "molecular function"
+  },
+  {
+    "code": "GO:0003917",
+    "name": "DNA topoisomerase type I (single strand cut, ATP-independent) activity",
+    "namespace": "molecular function"
+  },
+  {
+    "code": "GO:0004842",
+    "name": "ubiquitin-protein transferase activity",
+    "namespace": "molecular function"
+  },
+  {
+    "code": "GO:0005524",
+    "name": "ATP binding",
+    "namespace": "molecular function"
+  },
+  {
+    "code": "GO:0005634",
+    "name": "nucleus",
+    "namespace": "cellular component"
+  },
+  {
+    "code": "GO:0005737",
+    "name": "cytoplasm",
+    "namespace": "cellular component"
+  },
+  {
+    "code": "GO:0008152",
+    "name": "metabolic process",
+    "namespace": "biological process"
+  },
+  {
+    "code": "GO:0016567",
+    "name": "protein ubiquitination",
+    "namespace": "biological process"
+  },
+  {
+    "code": "GO:0046872",
+    "name": "metal ion binding",
+    "namespace": "molecular function"
+  },
+  {
+    "code": "GO:0070696",
+    "name": "transmembrane receptor protein serine/threonine kinase binding",
+    "namespace": "molecular function"
   }
 ]

--- a/src/test/api/resources/unipept/interpros.json
+++ b/src/test/api/resources/unipept/interpros.json
@@ -688,5 +688,45 @@
     "code": "IPR042185",
     "category": "Homologous_superfamily",
     "name": "Serpin superfamily, domain 2"
+  },
+  {
+    "code": "IPR003613",
+    "category": "Domain",
+    "name": "U box domain"
+  },
+  {
+    "code": "IPR009767",
+    "category": "Domain",
+    "name": "DNA helicase, TraI type"
+  },
+  {
+    "code": "IPR014059",
+    "category": "Domain",
+    "name": "Conjugative relaxase, N-terminal"
+  },
+  {
+    "code": "IPR014129",
+    "category": "Family",
+    "name": "Conjugative transfer relaxase protein TraI"
+  },
+  {
+    "code": "IPR011989",
+    "category": "Homologous_superfamily",
+    "name": "Armadillo-like helical"
+  },
+  {
+    "code": "IPR013083",
+    "category": "Homologous_superfamily",
+    "name": "Zinc finger, RING/FYVE/PHD-type"
+  },
+  {
+    "code": "IPR016024",
+    "category": "Homologous_superfamily",
+    "name": "Armadillo-type fold"
+  },
+  {
+    "code": "IPR000225",
+    "category": "Repeat",
+    "name": "Armadillo"
   }
 ]

--- a/src/test/api/resources/unipept/proteins.json
+++ b/src/test/api/resources/unipept/proteins.json
@@ -307,5 +307,72 @@
         ]
       }
     ]
+  },
+  {
+    "peptide": "ATSST",
+    "result": [
+      {
+        "uniprotAccessionId": "Q9C7G1",
+        "name": "U-box domain-containing protein 45",
+        "organism": 3702,
+        "ecNumbers": [
+          "2.3.2.27"
+        ],
+        "goTerms": [
+          "GO:0005737",
+          "GO:0005634",
+          "GO:0070696",
+          "GO:0004842",
+          "GO:0016567"
+        ],
+        "interproEntries": [
+          "IPR011989",
+          "IPR016024",
+          "IPR000225",
+          "IPR003613",
+          "IPR013083"
+        ]
+      },
+      {
+        "uniprotAccessionId": "P14565",
+        "name": "DNA helicase I",
+        "organism": 83333,
+        "ecNumbers": [
+          "5.6.2.1",
+          "3.6.4.12"
+        ],
+        "goTerms": [
+          "GO:0005737",
+          "GO:0005524",
+          "GO:0003677",
+          "GO:0003678",
+          "GO:0003917",
+          "GO:0046872",
+          "GO:0000746",
+          "GO:0008152"
+        ],
+        "interproEntries": [
+          "IPR014059",
+          "IPR014129",
+          "IPR009767",
+          "IPR027417",
+          "IPR040668",
+          "IPR040987",
+          "IPR014862"
+        ]
+      },
+      {
+        "uniprotAccessionId": "Q05858",
+        "name": "Formin",
+        "organism": 9031,
+        "ecNumbers": [],
+        "goTerms": [],
+        "interproEntries": [
+          "IPR015425",
+          "IPR042201",
+          "IPR001265"
+        ]
+      }
+    ]
   }
 ]

--- a/src/test/mocks/HtmlToImage.ts
+++ b/src/test/mocks/HtmlToImage.ts
@@ -1,0 +1,10 @@
+export default class HtmlToImage {
+    public async toSvgDataURL(url: string): Promise<string> {
+        // Just do nothing and return the same url.
+        return url;
+    }
+
+    public async toPng(domNode: HTMLElement, options?) {
+        return "nothing";
+    }
+}

--- a/src/test/mocks/MockTreeview.ts
+++ b/src/test/mocks/MockTreeview.ts
@@ -1,0 +1,3 @@
+export default class MockTreeview {
+    public reset() {}
+}

--- a/src/test/mocks/jQuery.ts
+++ b/src/test/mocks/jQuery.ts
@@ -1,0 +1,22 @@
+/**
+ * Mock of the part of the jQuery-interface that's used by some of the components that are being tested.
+ *
+ * @author Pieter Verschaffelt
+ */
+import MockTreeview from "@/test/mocks/MockTreeview";
+
+export default function $(args: any) {
+    return new jQueryMock();
+}
+
+class jQueryMock {
+    constructor() {}
+
+    public treeview(data: any): MockTreeview {
+        return new MockTreeview();
+    }
+
+    public html(args: string): jQueryMock {
+        return this;
+    }
+}


### PR DESCRIPTION
This PR introduces 3 new components for displaying all associated functional annotations of a protein. These components are very similar to the way this information is displayed for metaproteomics analysis. All code involved in these tables has been refactored, to avoid code duplication with the metaproteomics tables.

Screenshots:
_SingleGoSummaryCard:_
![image](https://user-images.githubusercontent.com/9608686/79116166-061fe800-7d88-11ea-88ff-2d38d8108c05.png)

_SingleEcSummaryCard:_
![image](https://user-images.githubusercontent.com/9608686/79116057-c1944c80-7d87-11ea-97a4-39f97a1b30df.png)

_SingleInterproSummaryCard:_
![image](https://user-images.githubusercontent.com/9608686/79115887-52b6f380-7d87-11ea-9c02-640accaf687f.png)
_Filtering per namespace:_
![image](https://user-images.githubusercontent.com/9608686/79115910-67938700-7d87-11ea-8510-19bd3f38ca25.png)



