### PR TITLE
OffscreenCanvas support for Firefox and Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unipept-web-components",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": false,
   "typings": "src/",
   "scripts": {

--- a/src/business/storage/browser/assay/BrowserStorageDataReader.ts
+++ b/src/business/storage/browser/assay/BrowserStorageDataReader.ts
@@ -15,6 +15,8 @@ export default class BrowserStorageDataReader extends BrowserAssayVisitor {
         const parsedPeptides = JSON.parse(peptidesSerialized);
         mpAssay.setPeptides(parsedPeptides.peptides);
 
+        console.log(mpAssay);
+
         return;
     }
 }

--- a/src/business/storage/browser/assay/BrowserStorageDataReader.ts
+++ b/src/business/storage/browser/assay/BrowserStorageDataReader.ts
@@ -15,8 +15,6 @@ export default class BrowserStorageDataReader extends BrowserAssayVisitor {
         const parsedPeptides = JSON.parse(peptidesSerialized);
         mpAssay.setPeptides(parsedPeptides.peptides);
 
-        console.log(mpAssay);
-
         return;
     }
 }

--- a/src/components/utils/ImageDownloadModal.vue
+++ b/src/components/utils/ImageDownloadModal.vue
@@ -100,7 +100,22 @@ export default class ImageDownloadModal extends Vue {
     async svg2pngDataURL(svgSelector: string) : Promise<string> {
         const el = $(svgSelector).get(0);
 
-        const canvas = new OffscreenCanvas(el.clientWidth, el.clientHeight);
+        let canvas;
+
+        if (window.OffscreenCanvas) {
+            canvas = new OffscreenCanvas(el.clientWidth, el.clientHeight);
+        } else {
+            const cnvs = document.createElement("canvas");
+            cnvs.width = el.clientWidth;
+            cnvs.height = el.clientHeight;
+
+            cnvs["convertToBlob"] = async() => {
+                return new Promise(resolve => {
+                    cnvs.toBlob(resolve);
+                });
+            };
+            canvas = cnvs;
+        }
 
         // automatically size canvas to svg element and render
         const canvgInstance = await Canvg.from(canvas.getContext("2d"), el.outerHTML, presets.offscreen());


### PR DESCRIPTION
Firefox and Safari both apparently do not support OffscreenCanvas which is required to convert the visualisations to PNG images. This PR introduces a fallback for the OffscreenCanvas (based on a real Canvas) and thus fixes the image downloads for Firefox and Safari (see https://github.com/unipept/unipept/issues/1032)