### PR TITLE
Perform requests in Pept2DataCommunicator in parallel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8447,13 +8447,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
     "async-each": {
       "version": "1.0.3",
@@ -16342,6 +16338,15 @@
         "once": "^1.4.0"
       },
       "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -22182,6 +22187,15 @@
         "recast": "^0.17.3"
       },
       "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
         "doctrine": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -23058,6 +23072,17 @@
             "async": "^2.6.2",
             "debug": "^3.1.1",
             "mkdirp": "^0.5.1"
+          },
+          "dependencies": {
+            "async": {
+              "version": "2.6.3",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+              "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+              "dev": true,
+              "requires": {
+                "lodash": "^4.17.14"
+              }
+            }
           }
         },
         "prismjs": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "dependencies": {
     "@types/uuid": "^3.4.7",
+    "async": "^3.2.0",
     "axios": "^0.19.0",
     "babel-polyfill": "^6.26.0",
     "canvg": "^3.0.5",

--- a/src/business/communication/peptides/Pept2DataCommunicator.ts
+++ b/src/business/communication/peptides/Pept2DataCommunicator.ts
@@ -74,15 +74,17 @@ export default class Pept2DataCommunicator {
                 NetworkConfiguration.BASE_URL
             );
 
+            let previousProgress: number = 0;
 
             obs.subscribe(message => {
                 if (message.type === "progress") {
-                    if (progressListener) {
+                    if (progressListener && message.value > previousProgress) {
+                        previousProgress = message.value;
                         progressListener.onProgressUpdate(message.value);
                     }
                 } else if (message.type === "result") {
                     const resultMap = message.value;
-                    const config = JSON.stringify(configuration) + NetworkConfiguration.BASE_URL;
+                    const config = configuration.enableMissingCleavageHandling.toString() + NetworkConfiguration.BASE_URL;
 
                     if (!Pept2DataCommunicator.configurationToResponses.has(config)) {
                         Pept2DataCommunicator.configurationToResponses.set(config, new Map());
@@ -120,7 +122,7 @@ export default class Pept2DataCommunicator {
         configuration: SearchConfiguration
     ): Promise<PeptideTrust> {
         await this.process(countTable, configuration);
-        const responseMap = this.configurationToResponses.get(JSON.stringify(configuration) + NetworkConfiguration.BASE_URL);
+        const responseMap = this.configurationToResponses.get(configuration.enableMissingCleavageHandling.toString() + NetworkConfiguration.BASE_URL);
 
         let matchedPeptides: number = 0;
         let missedPeptides: Peptide[] = [];
@@ -145,7 +147,7 @@ export default class Pept2DataCommunicator {
      * @return The data that was retrieved through Unipept's API if the peptide is known. Returns undefined otherwise.
      */
     public static getPeptideResponse(peptide: string, configuration: SearchConfiguration): PeptideDataResponse {
-        const configString = JSON.stringify(configuration) + NetworkConfiguration.BASE_URL;
+        const configString = configuration.enableMissingCleavageHandling.toString() + NetworkConfiguration.BASE_URL;
         const responseMap = this.configurationToResponses.get(configString);
         if (!responseMap) {
             return undefined;
@@ -154,12 +156,12 @@ export default class Pept2DataCommunicator {
     }
 
     public static getPeptideResponseMap(configuration: SearchConfiguration): Map<Peptide, PeptideDataResponse> {
-        const configString = JSON.stringify(configuration) + NetworkConfiguration.BASE_URL;
+        const configString = configuration.enableMissingCleavageHandling.toString() + NetworkConfiguration.BASE_URL;
         return Pept2DataCommunicator.configurationToResponses.get(configString);
     }
 
     private static getUnprocessedPeptides(peptides: Peptide[], configuration: SearchConfiguration): Peptide[] {
-        const configString = JSON.stringify(configuration) + NetworkConfiguration.BASE_URL;
+        const configString = configuration.enableMissingCleavageHandling.toString() + NetworkConfiguration.BASE_URL;
         if (!this.configurationToProcessed.has(configString)) {
             return peptides;
         }

--- a/src/business/communication/peptides/__tests__/Pept2DataCommunicator.spec.ts
+++ b/src/business/communication/peptides/__tests__/Pept2DataCommunicator.spec.ts
@@ -127,8 +127,10 @@ describe("Pept2DataCommunicator", () => {
             peptides: [AAAAA, AALTER, FATSDLNDLYR]
         }));
 
+        // Only the missing cleavage handling is considered when caching the results, since this is the only parameter
+        // that's passed on to the server.
         const searchConfig1 = new SearchConfiguration(true, true, false);
-        const searchConfig2 = new SearchConfiguration(false, false, false);
+        const searchConfig2 = new SearchConfiguration(true, true, true);
 
         await Pept2DataCommunicator.process(countTable, searchConfig1);
 

--- a/src/components/analysis/SearchSettingsForm.vue
+++ b/src/components/analysis/SearchSettingsForm.vue
@@ -1,6 +1,5 @@
 <template>
-    <div class="search-settings-form">
-        <h3>Search settings</h3>
+    <div :class="{'search-settings-form': true, 'd-flex': true, 'flex-row': horizontal, 'justify-space-between': horizontal }">
         <v-tooltip top>
             <template v-slot:activator="{ on }">
                 <div v-on="on">
@@ -72,10 +71,15 @@ export default class SearchSetingsForm extends Vue {
     @Prop({ default: true }) equateIl!: boolean;
     @Prop({ default: true }) filterDuplicates!: boolean;
     @Prop({ default: false }) missingCleavage!: boolean;
+    /**
+     * Show the component in a horizontal or vertical fashion? Set to true to show the different checkboxes on one line.
+     */
+    @Prop({ required: false, default: true })
+    private horizontal: boolean;
 
-    equateIlData: boolean = this.equateIl;
-    filterDuplicatesData: boolean = this.filterDuplicates;
-    missingCleavageData: boolean = this.missingCleavage;
+    private equateIlData: boolean = this.equateIl;
+    private filterDuplicatesData: boolean = this.filterDuplicates;
+    private missingCleavageData: boolean = this.missingCleavage;
 
     @Watch("equateIl") onEquateIlChanged() {
         this.equateIlData = this.equateIl;
@@ -94,6 +98,6 @@ export default class SearchSetingsForm extends Vue {
 
 <style scoped>
     .search-settings-form .v-input--selection-controls {
-        margin-top: 0px;
+        margin-top: 0;
     }
 </style>

--- a/src/components/analysis/statistics/ExperimentSummaryCard.vue
+++ b/src/components/analysis/statistics/ExperimentSummaryCard.vue
@@ -12,8 +12,9 @@ change the currently active search settings and redo the analysis of all selecte
             </card-title>
         </card-header>
         <v-card-text style="flex-grow: 1; display: flex; flex-direction: column;">
-            <h3>Peptide list</h3>
+            <div class="subtitle-1">Peptide list</div>
             <v-textarea :readonly="true" v-model="peptideList" :loading="disabled || exportLoading"></v-textarea>
+            <div class="subtitle-1">Search settings</div>
             <search-settings-form
                 :disabled="disabled"
                 :equate-il.sync="equateIl"

--- a/src/components/visualizations/SingleDatasetVisualizationsCard.vue
+++ b/src/components/visualizations/SingleDatasetVisualizationsCard.vue
@@ -269,8 +269,8 @@ export default class SingleDatasetVisualizationsCard extends Vue {
 
     @Watch("peptideCountTable")
     private async onPeptideCountTableChanged() {
+        this.tree = null;
         if (this.peptideCountTable) {
-            this.tree = null;
             const taxaCountProcessor = new LcaCountTableProcessor(this.peptideCountTable, this.searchConfiguration);
             const taxaCounts = await taxaCountProcessor.getCountTable();
 


### PR DESCRIPTION
By performing 6 requests in parallel in the Pept2DataCommunicator, we can achieve a significant speedup of the process time for a sample (from 45s to 26s for a sample with 78 000 unique peptides).