### PR TITLE
Reuse workers as much as possible

### DIFF
--- a/src/business/communication/peptides/Pept2DataCommunicator.ts
+++ b/src/business/communication/peptides/Pept2DataCommunicator.ts
@@ -21,6 +21,7 @@ export default class Pept2DataCommunicator {
     // Keeps track of which peptides have been processed per concrete configuration
     private static configurationToProcessed = new Map<string, Set<Peptide>>();
     private static inProgress: Promise<void>;
+    private static worker;
 
     /**
      * Look up all peptide data in the Unipept API for each peptide in the given count table. It is guaranteed that
@@ -62,9 +63,11 @@ export default class Pept2DataCommunicator {
                 return;
             }
 
-            const spawnedProcess = await spawn(new Worker("./Pept2Data.worker.ts"));
+            if (!Pept2DataCommunicator.worker) {
+                Pept2DataCommunicator.worker = await spawn(new Worker("./Pept2Data.worker.ts"));
+            }
 
-            const obs: Observable<{ type: string, value: any }> = spawnedProcess(
+            const obs: Observable<{ type: string, value: any }> = Pept2DataCommunicator.worker(
                 peptides,
                 {
                     equateIl: configuration.equateIl,

--- a/src/business/processors/raw/PeptideCountTableProcessor.ts
+++ b/src/business/processors/raw/PeptideCountTableProcessor.ts
@@ -5,6 +5,8 @@ import { spawn, Worker } from "threads"
 
 
 export default class PeptideCountTableProcessor {
+    private static worker;
+
     /**
      * Convert a list of peptides into a count table. This function directly filters the given list of peptides, based
      * on the search configuration given here.
@@ -17,8 +19,10 @@ export default class PeptideCountTableProcessor {
         peptides: Peptide[],
         searchConfiguration: SearchConfiguration
     ): Promise<CountTable<Peptide>> {
-        const peptideWorker = await spawn(new Worker("./PeptideCountProcessor.worker.ts"));
-        const [peptideCountsMapping, totalFrequency] = await peptideWorker(peptides, searchConfiguration);
+        if (!PeptideCountTableProcessor.worker) {
+            PeptideCountTableProcessor.worker = await spawn(new Worker("./PeptideCountProcessor.worker.ts"));
+        }
+        const [peptideCountsMapping, totalFrequency] = await PeptideCountTableProcessor.worker(peptides, searchConfiguration);
         return new CountTable<Peptide>(peptideCountsMapping, totalFrequency);
     }
 }

--- a/src/business/processors/taxonomic/ncbi/HighlightedTreeProcessor.ts
+++ b/src/business/processors/taxonomic/ncbi/HighlightedTreeProcessor.ts
@@ -10,7 +10,8 @@ import { NcbiId } from "./../../../ontology/taxonomic/ncbi/NcbiTaxon";
  */
 export default class HighlightedTreeProcessor {
     private static pool = Pool(
-        () => spawn(new Worker("./HighlightTree.worker.ts"))
+        () => spawn(new Worker("./HighlightTree.worker.ts")),
+        4
     );
 
     public async computeHighlightedTree(


### PR DESCRIPTION
By reusing spawned workers as much as possible, we can drastically decrease the memory requirements of the web components.