### PR TITLE
Improve image export functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18283,10 +18283,10 @@
             "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=",
             "dev": true
         },
-        "html-to-image-no-fonts": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/html-to-image-no-fonts/-/html-to-image-no-fonts-0.1.2.tgz",
-            "integrity": "sha512-ydCALOnrQV7Rg3g9+peWZ+//k8uMz6nVZ68nIf0AMpDwP1dP5xf73AO7/9pPzWmbzqxA/ZaQ2d82JdEIcUb5jQ=="
+        "html-to-image": {
+            "version": "1.3.20",
+            "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.3.20.tgz",
+            "integrity": "sha512-Pkc4rzqml0/VDPi81Y+ljQH+eko87FzwZpNfoEmj2urWdAiu2u9LxSoOJpWI/++I9uaR3tPe1xLq/VZmwOqVSw=="
         },
         "html-webpack-plugin": {
             "version": "3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33360,9 +33360,9 @@
             }
         },
         "unipept-heatmap": {
-            "version": "2.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/unipept-heatmap/-/unipept-heatmap-2.0.0-beta.5.tgz",
-            "integrity": "sha512-jtSdKSem+tnvHWDSzfTu4UWaej6g56TbMxmf6bsJiFJy0GKt0e0NSS0BCOTFTeoFmfBbOMbZvwVGW2y38RysOA==",
+            "version": "2.0.0-beta.6",
+            "resolved": "https://registry.npmjs.org/unipept-heatmap/-/unipept-heatmap-2.0.0-beta.6.tgz",
+            "integrity": "sha512-Ob1x3UUYQWIYaq59F8xKjfMFefRZrN3J585AfSlGjTmGAsFiVnaSff53JQBfMt/pMmAk/nzM34WIKkDTZTQ04Q==",
             "requires": {
                 "@types/d3": "^5.16.0",
                 "@types/sanitize-html": "^1.27.0",
@@ -33411,9 +33411,9 @@
                     }
                 },
                 "core-js": {
-                    "version": "3.8.1",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.1.tgz",
-                    "integrity": "sha512-9Id2xHY1W7m8hCl8NkhQn5CufmF/WuR30BTRewvCXc1aZd3kMECwNZ69ndLbekKfakw9Rf2Xyc+QR6E7Gg+obg=="
+                    "version": "3.8.2",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.2.tgz",
+                    "integrity": "sha512-FfApuSRgrR6G5s58casCBd9M2k+4ikuu4wbW6pJyYU7bd9zvFc9qf7vr5xmrZOhT9nn+8uwlH1oRR9jTnFoA3A=="
                 },
                 "d3": {
                     "version": "5.16.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "jquery": "^3.4.1",
         "observable-fns": "^0.5.1",
         "shared-memory-datastructures": "0.1.9",
-        "unipept-heatmap": "^2.0.0-beta.5",
+        "unipept-heatmap": "^2.0.0-beta.6",
         "unipept-visualizations": "^1.7.3",
         "uuid": "^3.4.0",
         "vue": "^2.6.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "unipept-web-components",
-    "version": "1.2.8",
+    "version": "1.3.0",
     "private": false,
     "types": "./types",
     "scripts": {
@@ -30,7 +30,7 @@
         "crypto-js": "^3.1.9-1",
         "d3": "^5.11.0",
         "d3-selection": "^1.4.0",
-        "html-to-image-no-fonts": "^0.1.2",
+        "html-to-image": "^1.3.20",
         "html2canvas": "^1.0.0-rc.5",
         "jquery": "^3.4.1",
         "observable-fns": "^0.5.1",

--- a/src/business/image/DomElementToPngSource.ts
+++ b/src/business/image/DomElementToPngSource.ts
@@ -1,0 +1,20 @@
+import PngSource from "@/business/image/PngSource";
+import PngUtils from "@/business/image/PngUtils";
+
+export default class DomElementToPngSource implements PngSource {
+    constructor(
+        private domElement: HTMLElement
+    ) {}
+
+    public getOriginalHeight(): number {
+        return this.domElement.clientHeight;
+    }
+
+    public getOriginalWidth(): number {
+        return this.domElement.clientWidth;
+    }
+
+    public toDataUrl(scaling: number): Promise<string> {
+        return PngUtils.htmlElementToPngDataUrl(this.domElement, scaling);
+    }
+}

--- a/src/business/image/PngSource.ts
+++ b/src/business/image/PngSource.ts
@@ -1,0 +1,19 @@
+export default interface PngSource {
+    /**
+     * Get a valid PNG data URL that contains all PNG data for this image, enlarged with the required scaling factor.
+     *
+     * @param scaling Positive floating point value that indicates how much the image should be enlarged (both
+     * dimensions of the image are enlarged by this value).
+     */
+    toDataUrl(scaling: number): Promise<string>;
+
+    /**
+     * Original width of this PNG source image in pixels (as if scaling factor 1 was to be used).
+     */
+    getOriginalWidth(): number;
+
+    /**
+     * Original height of this PNG source image in pixels (as if scaling factor 1 was to be used).
+     */
+    getOriginalHeight(): number;
+}

--- a/src/business/image/PngUtils.ts
+++ b/src/business/image/PngUtils.ts
@@ -1,0 +1,56 @@
+import htmlToImage from "html-to-image-no-fonts";
+import Canvg, { presets } from "canvg";
+
+export default class PngUtils {
+    public static async htmlElementToPngDataUrl(element: HTMLElement): Promise<string> {
+        return await htmlToImage.toPng(element);
+    }
+
+    public static async svgElementToPngDataUrl(element: SVGElement, scalingFactor: number): Promise<string> {
+        return PngUtils.svgStringToPngDataUrl(
+            element.outerHTML,
+            element.clientWidth,
+            element.clientHeight,
+            scalingFactor
+        );
+    }
+
+    public static async svgStringToPngDataUrl(
+        svgString: string,
+        originalWidth: number,
+        originalHeight: number,
+        scalingFactor: number
+    ): Promise<string> {
+        let canvas;
+
+        if (window.OffscreenCanvas) {
+            canvas = new OffscreenCanvas(originalWidth, originalHeight);
+        } else {
+            const cnvs = document.createElement("canvas");
+            cnvs.width = originalWidth;
+            cnvs.height = originalHeight;
+
+            cnvs["convertToBlob"] = async() => {
+                return new Promise(resolve => {
+                    cnvs.toBlob(resolve);
+                });
+            };
+            canvas = cnvs;
+        }
+
+        const canvgInstance = await Canvg.fromString(canvas.getContext("2d"), svgString, presets.offscreen());
+        canvgInstance.resize(
+            canvas.width * scalingFactor,
+            canvas.height * scalingFactor
+        );
+
+        await canvgInstance.render();
+
+        const blob = await canvas.convertToBlob();
+        return URL.createObjectURL(blob);
+    }
+
+    public static canvasElementToPngDataUrl(element: HTMLCanvasElement): string {
+        return element.toDataURL();
+    }
+}

--- a/src/business/image/PngUtils.ts
+++ b/src/business/image/PngUtils.ts
@@ -24,11 +24,11 @@ export default class PngUtils {
         let canvas;
 
         if (window.OffscreenCanvas) {
-            canvas = new OffscreenCanvas(originalWidth, originalHeight);
+            canvas = new OffscreenCanvas(originalWidth * scalingFactor, originalHeight * scalingFactor);
         } else {
             const cnvs = document.createElement("canvas");
-            cnvs.width = originalWidth;
-            cnvs.height = originalHeight;
+            cnvs.width = originalWidth * scalingFactor;
+            cnvs.height = originalHeight * scalingFactor;
 
             cnvs["convertToBlob"] = async() => {
                 return new Promise(resolve => {
@@ -38,11 +38,15 @@ export default class PngUtils {
             canvas = cnvs;
         }
 
+        // Apparently we need to modify the SVG-file itself to make sure that the PNG is rendered at the requested
+        // scaling factor.
+        svgString = svgString
+            .replace(/width="[0-9]*%?"/, `width="${originalWidth * scalingFactor}"`)
+            .replace(/height="[0-9]*%?"/, `height="${originalHeight * scalingFactor}"`)
+            .replace(/viewBox="[^"]*"/, "")
+            .replace("svg", `svg viewBox="0 0 ${originalWidth} ${originalHeight}"`);
+
         const canvgInstance = await Canvg.fromString(canvas.getContext("2d"), svgString, presets.offscreen());
-        canvgInstance.resize(
-            canvas.width * scalingFactor,
-            canvas.height * scalingFactor
-        );
 
         await canvgInstance.render();
 

--- a/src/business/image/PngUtils.ts
+++ b/src/business/image/PngUtils.ts
@@ -1,9 +1,9 @@
-import htmlToImage from "html-to-image-no-fonts";
+import { toPng } from "html-to-image";
 import Canvg, { presets } from "canvg";
 
 export default class PngUtils {
-    public static async htmlElementToPngDataUrl(element: HTMLElement): Promise<string> {
-        return await htmlToImage.toPng(element);
+    public static async htmlElementToPngDataUrl(element: HTMLElement, scalingFactor: number): Promise<string> {
+        return await toPng(element, { pixelRatio: scalingFactor });
     }
 
     public static async svgElementToPngDataUrl(element: SVGElement, scalingFactor: number): Promise<string> {

--- a/src/business/image/SvgElementToPngSource.ts
+++ b/src/business/image/SvgElementToPngSource.ts
@@ -1,0 +1,22 @@
+import PngSource from "@/business/image/PngSource";
+import PngUtils from "@/business/image/PngUtils";
+
+/**
+ * This class implements the PngSource interface and provides some generic methods that convert SVG-data to a
+ * PNG-element.
+ */
+export default class SvgElementToPngSource implements PngSource {
+    constructor(private element: SVGElement) {}
+
+    public async toDataUrl(scaling: number): Promise<string> {
+        return PngUtils.svgElementToPngDataUrl(this.element, scaling);
+    }
+
+    public getOriginalWidth(): number {
+        return this.element.clientWidth;
+    }
+
+    public getOriginalHeight(): number {
+        return this.element.clientHeight;
+    }
+}

--- a/src/business/image/SvgStringToPngSource.ts
+++ b/src/business/image/SvgStringToPngSource.ts
@@ -1,0 +1,36 @@
+import PngSource from "@/business/image/PngSource";
+import SvgUtils from "@/business/image/SvgUtils";
+import PngUtils from "@/business/image/PngUtils";
+
+export default class SvgStringToPngSource implements PngSource {
+    constructor(private svgString: string) {}
+
+    public getOriginalHeight(): number {
+        return Number.parseInt(
+            this.svgString.match(
+                /<svg[^>]*height="[0-9]*"/)[0].replace(/.*height="([0-9]*)".*/,
+                "$1"
+            )
+        );
+    }
+
+    public getOriginalWidth(): number {
+        return Number.parseInt(
+            this.svgString.match(
+                /<svg[^>]*width="[0-9]*"/)[0].replace(/.*width="([0-9]*)".*/,
+                "$1"
+            )
+        );
+    }
+
+    public toDataUrl(scaling: number): Promise<string> {
+        console.log(this.getOriginalHeight());
+        console.log(this.getOriginalWidth());
+        return PngUtils.svgStringToPngDataUrl(
+            this.svgString,
+            this.getOriginalWidth(),
+            this.getOriginalHeight(),
+            scaling
+        );
+    }
+}

--- a/src/business/image/SvgStringToPngSource.ts
+++ b/src/business/image/SvgStringToPngSource.ts
@@ -1,5 +1,4 @@
 import PngSource from "@/business/image/PngSource";
-import SvgUtils from "@/business/image/SvgUtils";
 import PngUtils from "@/business/image/PngUtils";
 
 export default class SvgStringToPngSource implements PngSource {
@@ -24,8 +23,6 @@ export default class SvgStringToPngSource implements PngSource {
     }
 
     public toDataUrl(scaling: number): Promise<string> {
-        console.log(this.getOriginalHeight());
-        console.log(this.getOriginalWidth());
         return PngUtils.svgStringToPngDataUrl(
             this.svgString,
             this.getOriginalWidth(),

--- a/src/business/image/SvgUtils.ts
+++ b/src/business/image/SvgUtils.ts
@@ -1,0 +1,12 @@
+export default class SvgUtils {
+    public static elementToSvgDataUrl(element: SVGElement) {
+        const svgString = new XMLSerializer().serializeToString(element);
+        return SvgUtils.svgStringToSvgDataUrl(svgString);
+    }
+
+    public static svgStringToSvgDataUrl(svgString: string) {
+        const decoded = unescape(encodeURIComponent(svgString));
+        const base64 = btoa(decoded);
+        return `data:image/svg+xml;base64,${base64}`;
+    }
+}

--- a/src/components/analysis/functional/FunctionalSummaryCard.vue
+++ b/src/components/analysis/functional/FunctionalSummaryCard.vue
@@ -169,7 +169,6 @@
             </v-tabs-items>
         </v-card>
         <div id="tooltip" class="tip"></div>
-        <image-download-modal ref="imageDownloadModal"/>
     </div>
 </template>
 
@@ -183,21 +182,14 @@ import IndeterminateProgressBar from "../../custom/IndeterminateProgressBar.vue"
 import CardHeader from "../../custom/CardHeader.vue";
 import QuickGoCard from "./QuickGoCard.vue";
 
-import ImageDownloadModal from "../../utils/ImageDownloadModal.vue";
-
 import { Peptide } from "./../../../business/ontology/raw/Peptide";
 import { CountTable } from "./../../../business/counts/CountTable";
 import NcbiTaxon, { NcbiId } from "./../../../business/ontology/taxonomic/ncbi/NcbiTaxon";
-import SearchConfiguration from "./../../../business/configuration/SearchConfiguration";
 import LcaCountTableProcessor from "./../../../business/processors/taxonomic/ncbi/LcaCountTableProcessor";
-import PeptideCountTableProcessor from "./../../../business/processors/raw/PeptideCountTableProcessor";
-import NcbiOntologyProcessor from "./../../../business/ontology/taxonomic/ncbi/NcbiOntologyProcessor";
 import Tree from "./../../../business/ontology/taxonomic/Tree";
-import TreeNode from "./../../../business/ontology/taxonomic/TreeNode";
 import MultiGoSummaryCard from "./../multi/MultiGoSummaryCard.vue";
 import MultiEcSummaryCard from "./../multi/MultiEcSummaryCard.vue";
 import MultiInterproSummaryCard from "./../multi/MultiInterproSummaryCard.vue";
-import CommunicationSource from "./../../../business/communication/source/CommunicationSource";
 import ProteomicsAssay from "./../../../business/entities/assay/ProteomicsAssay";
 import { Ontology } from "./../../../business/ontology/Ontology";
 
@@ -210,12 +202,10 @@ import { Ontology } from "./../../../business/ontology/Ontology";
         IndeterminateProgressBar,
         FilterFunctionalAnnotationsDropdown,
         QuickGoCard,
-        ImageDownloadModal,
     }
 })
 export default class FunctionalSummaryCard extends Vue {
     $refs!: {
-        imageDownloadModal: ImageDownloadModal,
         goSummaryCard: MultiGoSummaryCard,
         ecSummaryCard: MultiEcSummaryCard,
         interproSummaryCard: MultiInterproSummaryCard

--- a/src/components/analysis/multi/MultiEcSummaryCard.vue
+++ b/src/components/analysis/multi/MultiEcSummaryCard.vue
@@ -40,7 +40,6 @@
                     :enableAutoExpand="true">
                 </treeview>
             </v-card>
-            <image-download-modal ref="imageDownloadModal"></image-download-modal>
         </v-card-text>
     </v-card>
 </template>
@@ -79,10 +78,9 @@ import CommunicationSource from "@/business/communication/source/CommunicationSo
 import TreeViewNode from "@/components/visualizations/TreeViewNode";
 import Treeview from "@/components/visualizations/Treeview.vue";
 import AmountTable from "@/components/tables/AmountTable.vue";
-import ImageDownloadModal from "@/components/utils/ImageDownloadModal.vue";
 
 @Component({
-    components: { FilterFunctionalAnnotationsDropdown, Treeview, AmountTable, ImageDownloadModal }
+    components: { FilterFunctionalAnnotationsDropdown, Treeview, AmountTable }
 })
 export default class MultiEcSummaryCard extends Vue {
     @Prop({ required: true })

--- a/src/components/analysis/single/SingleEcSummaryCard.vue
+++ b/src/components/analysis/single/SingleEcSummaryCard.vue
@@ -36,7 +36,6 @@
                     :enableAutoExpand="true">
                 </treeview>
             </v-card>
-            <image-download-modal ref="imageDownloadModal"></image-download-modal>
         </v-card-text>
     </v-card>
 </template>
@@ -56,12 +55,11 @@ import AmountTableItemRetriever from "@/components/tables/AmountTableItemRetriev
 import AmountTable from "@/components/tables/AmountTable.vue";
 import SingleAmountTableItemRetriever from "@/components/analysis/single/SingleAmountTableItemRetriever";
 import Treeview from "@/components/visualizations/Treeview.vue";
-import ImageDownloadModal from "@/components/utils/ImageDownloadModal.vue";
 import { CountTable, Ontology } from "@/business";
 import TreeViewNode from "@/components/visualizations/TreeViewNode";
 
 @Component({
-    components: { AmountTable, Treeview, ImageDownloadModal }
+    components: { AmountTable, Treeview }
 })
 export default class SingleEcSummaryCard extends Vue {
     @Prop({ required: true })

--- a/src/components/heatmap/HeatmapVisualization.vue
+++ b/src/components/heatmap/HeatmapVisualization.vue
@@ -9,7 +9,12 @@
             <span class="dir text">Scroll to zoom, drag to pan.</span>
         </h2>
         <div ref="heatmapElement" style="width: 100%" v-once></div>
-        <image-download-modal ref="imageDownloadModal" />
+        <image-download-modal
+            v-model="downloadModalOpen"
+            base-file-name="unipept_comparative_heatmap"
+            :png-source="pngDataSource"
+            :svg-string="svgString"
+        />
     </div>
 </template>
 
@@ -18,9 +23,10 @@ import Vue from "vue";
 import Component, { mixins } from "vue-class-component";
 import { Prop, Watch } from "vue-property-decorator";
 import VisualizationMixin from "../visualizations/VisualizationMixin.vue";
-import { Heatmap, HeatmapSettings } from "unipept-heatmap";
+import { Heatmap } from "unipept-heatmap";
 import ImageDownloadModal from "./../utils/ImageDownloadModal.vue";
 import AnalyticsUtil from "@/business/analytics/AnalyticsUtil";
+import SvgStringToPngSource from "@/business/image/SvgStringToPngSource";
 
 @Component({
     components: {
@@ -30,7 +36,6 @@ import AnalyticsUtil from "@/business/analytics/AnalyticsUtil";
 export default class HeatmapVisualization extends mixins(VisualizationMixin) {
     $refs: {
         heatmapElement: any,
-        imageDownloadModal: ImageDownloadModal
     }
 
     @Prop({ default: false })
@@ -48,6 +53,10 @@ export default class HeatmapVisualization extends mixins(VisualizationMixin) {
 
     private heatmap: Heatmap;
     private rotated: boolean = false;
+
+    private downloadModalOpen: boolean = false;
+    private svgString: string = "";
+    private pngDataSource: SvgStringToPngSource = null;
 
     mounted() {
         this.initHeatmap();
@@ -115,11 +124,10 @@ export default class HeatmapVisualization extends mixins(VisualizationMixin) {
 
     private async download() {
         AnalyticsUtil.logToGoogle("Comparative analysis", "Save Image", "Heatmap");
-        const imageDownloadModal = this.$refs.imageDownloadModal as ImageDownloadModal;
-        await imageDownloadModal.downloadPNG(
-            "unipept_comparative_heatmap",
-            document.getElementsByTagName("canvas").item(0)
-        );
+        this.svgString = this.heatmap.toSVG()
+        this.pngDataSource = new SvgStringToPngSource(this.svgString);
+
+        this.downloadModalOpen = true;
     }
 }
 </script>

--- a/src/components/tables/AmountTable.vue
+++ b/src/components/tables/AmountTable.vue
@@ -79,7 +79,7 @@
                 </tooltip>
             </template>
         </v-data-table>
-        <image-download-modal ref="imageDownloadModal"/>
+<!--        <image-download-modal ref="imageDownloadModal"/>-->
     </div>
 </template>
 
@@ -321,11 +321,11 @@ export default class AmountTable extends Vue {
 
     private saveImage(term: AmountTableItem): void {
         AnalyticsUtil.logToGoogle("Multi peptide", "Save Image for FA");
-        const downloadModal = this.$refs.imageDownloadModal as ImageDownloadModal;
-        downloadModal.downloadSVG(
-            "unipept_treeview_" + term.code.replace(":", "_"),
-            "#" + this.treeViewId(term) + " svg"
-        );
+        // const downloadModal = this.$refs.imageDownloadModal as ImageDownloadModal;
+        // downloadModal.downloadSVG(
+        //     "unipept_treeview_" + term.code.replace(":", "_"),
+        //     "#" + this.treeViewId(term) + " svg"
+        // );
     }
 
     private async saveTableAsCsv(): Promise<void> {

--- a/src/components/tables/AmountTable.vue
+++ b/src/components/tables/AmountTable.vue
@@ -161,7 +161,7 @@ import SvgElementToPngSource from "@/business/image/SvgElementToPngSource";
 })
 export default class AmountTable extends Vue {
     $refs!: {
-        imageDownloadModal: ImageDownloadModal
+        dataTable: Vue
     }
 
     /*******************************************************************************************************************
@@ -342,7 +342,7 @@ export default class AmountTable extends Vue {
     private saveImage(term: AmountTableItem): void {
         AnalyticsUtil.logToGoogle("Multi peptide", "Save Image for FA");
         const svgElement = document.getElementById(`${this.treeViewId(term)}`)
-            .getElementsByTagName<SVGElement>("svg")
+            .getElementsByTagName("svg")
             .item(0);
         this.imageSvg = SvgUtils.elementToSvgDataUrl(svgElement);
         this.imagePngSource = new SvgElementToPngSource(svgElement);

--- a/src/components/utils/ImageDownloadModal.vue
+++ b/src/components/utils/ImageDownloadModal.vue
@@ -179,6 +179,7 @@ export default class ImageDownloadModal extends Vue {
     }
 
     private async savePNG() {
+        console.log("Scaling value: " + this.scalingValue);
         const resizedPngDataUrl = await this.pngSource.toDataUrl(this.scalingValue);
         NetworkUtils.downloadDataByLink(resizedPngDataUrl, this.baseFileName + ".png")
     }

--- a/src/components/visualizations/SingleDatasetVisualizationsCard.vue
+++ b/src/components/visualizations/SingleDatasetVisualizationsCard.vue
@@ -90,7 +90,7 @@
                             </v-card-text>
                         </div>
                     </v-card>
-                    <image-download-modal ref="imageDownloadModal" />
+<!--                    <image-download-modal ref="imageDownloadModal" />-->
                 </v-tab-item>
                 <v-tab-item>
                     <v-card flat>
@@ -291,17 +291,17 @@ export default class SingleDatasetVisualizationsCard extends Vue {
 
     private async prepareImage() {
         this.exitFullScreen();
-        const imageDownloadModal = this.$refs.imageDownloadModal as ImageDownloadModal;
+        // const imageDownloadModal = this.$refs.imageDownloadModal as ImageDownloadModal;
 
         AnalyticsUtil.logToGoogle("Multi Peptide", "Save Image", this.tabs[this.tab]);
         if (this.tabs[this.tab] === "Sunburst") {
             d3.selectAll(".toHide").attr("class", "arc hidden");
-            await imageDownloadModal.downloadSVG("unipept_sunburst", "#sunburstWrapper > .unipept-sunburst > svg")
+            // await imageDownloadModal.downloadSVG("unipept_sunburst", "#sunburstWrapper > .unipept-sunburst > svg")
             d3.selectAll(".hidden").attr("class", "arc toHide");
         } else if (this.tabs[this.tab] === "Treemap") {
-            await imageDownloadModal.downloadPNG("unipept_treemap", "#treemapWrapper > div")
+            // await imageDownloadModal.downloadPNG("unipept_treemap", "#treemapWrapper > div")
         } else {
-            await imageDownloadModal.downloadSVG("unipept_treeview", "#treeviewWrapper svg")
+            // await imageDownloadModal.downloadSVG("unipept_treeview", "#treeviewWrapper svg")
         }
     }
 

--- a/src/components/visualizations/Treeview.vue
+++ b/src/components/visualizations/Treeview.vue
@@ -124,6 +124,8 @@ export default class Treeview extends Vue {
                 enableAutoExpand: this.enableAutoExpand,
             }
 
+            console.log(settings);
+
             // Only these settings that are explicitly filled in should to be passed as an option
             for (let [settingsName, funcName] of this.settingNames) {
                 if (this[funcName]) {

--- a/src/components/visualizations/TreeviewVisualization.vue
+++ b/src/components/visualizations/TreeviewVisualization.vue
@@ -7,14 +7,12 @@
             <span class="dir text">Scroll to zoom, drag to pan, click a node to expand, right click a node to set as root</span>
         </h2>
         <treeview ref="treeview" :data="data" :autoResize="this.autoResize" :width="this.width" :height="this.height" :enableAutoExpand="true" :tooltip="tooltipFunction" :colors="colors" :rerootCallback="rerootCallback"></treeview>
-        <image-download-modal ref="imageDownloadModal" />
     </div>
 </template>
 
 <script lang="ts">
 import * as d3 from "d3";
 import * as d3Scale from "d3-scale";
-import Vue from "vue";
 import Component, { mixins } from "vue-class-component";
 import { Prop, Watch } from "vue-property-decorator";
 import { tooltipContent } from "./VisualizationHelper";
@@ -22,20 +20,16 @@ import VisualizationMixin from "./VisualizationMixin.vue";
 import Treeview from "./Treeview.vue";
 import Tree from "./../../business/ontology/taxonomic/Tree";
 import TreeNode from "./../../business/ontology/taxonomic/TreeNode";
-import AnalyticsUtil from "./../../business/analytics/AnalyticsUtil";
-import ImageDownloadModal from "./../utils/ImageDownloadModal.vue";
 
 @Component({
     components: {
-        Treeview,
-        ImageDownloadModal
+        Treeview
     }
 })
 export default class TreeviewVisualization extends mixins(VisualizationMixin) {
     $refs: {
         treeview: Treeview
         treeviewWrapper: Element
-        imageDownloadModal: ImageDownloadModal
     }
 
     @Prop({ required: true })

--- a/src/components/visualizations/TreeviewVisualization.vue
+++ b/src/components/visualizations/TreeviewVisualization.vue
@@ -4,9 +4,22 @@
             <span class="dir">
                 <v-btn x-small fab @click="reset()" :elevation="0"><v-icon>mdi-restore</v-icon></v-btn>
             </span>
-            <span class="dir text">Scroll to zoom, drag to pan, click a node to expand, right click a node to set as root</span>
+            <span class="dir text">
+                Scroll to zoom, drag to pan, click a node to expand, right click a node to set as root
+            </span>
         </h2>
-        <treeview ref="treeview" :data="data" :autoResize="this.autoResize" :width="this.width" :height="this.height" :enableAutoExpand="true" :tooltip="tooltipFunction" :colors="colors" :rerootCallback="rerootCallback"></treeview>
+        <treeview
+            ref="treeview"
+            :data="data"
+            :autoResize="autoResize"
+            :width="width"
+            :height="height"
+            :enableAutoExpand="true"
+            :tooltip="tooltipFunction"
+            :colors="colors"
+            :rerootCallback="rerootCallback"
+        >
+        </treeview>
     </div>
 </template>
 
@@ -41,12 +54,12 @@ export default class TreeviewVisualization extends mixins(VisualizationMixin) {
     private fullScreen: boolean;
     @Prop({ required: false, default: false })
     private autoResize: boolean;
-    @Prop({ required: false, default: -1 })
-    private width: number;
     @Prop({ required: false, default: 600 })
     private height: number;
     @Prop({ required: false, default: null })
     private tooltip: (d: any) => string;
+
+    private width: number = 0;
 
     private colors: (d: any) => string = (d: any) => {
         if (d.name === "Bacteria") return "#1565C0"; // blue
@@ -81,7 +94,7 @@ export default class TreeviewVisualization extends mixins(VisualizationMixin) {
     }
 
     private async initTreeview() {
-        this.width = this.width === -1 ? this.$refs.treeviewWrapper.clientWidth : this.width;
+        this.width = this.$refs.treeviewWrapper.clientWidth;
         if (this.tree) {
             this.data = this.tree.getRoot();
         }

--- a/types/business/communication/peptides/Pept2DataCommunicator.d.ts
+++ b/types/business/communication/peptides/Pept2DataCommunicator.d.ts
@@ -12,6 +12,7 @@ export default class Pept2DataCommunicator {
     static PEPTDATA_BATCH_SIZE: number;
     static MISSED_CLEAVAGE_BATCH: number;
     static PEPTDATA_ENDPOINT: string;
+    static NETWORK_ERROR_TIMEOUT: number;
     private cancelled;
     /**
      * Look up all peptide data in the Unipept API for each peptide in the given count table. It is guaranteed that
@@ -37,6 +38,6 @@ export default class Pept2DataCommunicator {
      * @return The data that was retrieved through Unipept's API if the peptide is known. Returns undefined otherwise.
      */
     getPeptideResponse(peptide: string, configuration: SearchConfiguration): PeptideData;
-    getPeptideResponseMap(configuration: SearchConfiguration): ShareableMap<Peptide, PeptideData>;
+    getPeptideResponseMap(configuration: SearchConfiguration): ShareableMap<string, PeptideData>;
     private getUnprocessedPeptides;
 }

--- a/types/business/image/PngSource.d.ts
+++ b/types/business/image/PngSource.d.ts
@@ -1,0 +1,17 @@
+export default interface PngSource {
+    /**
+     * Get a valid PNG data URL that contains all PNG data for this image, enlarged with the required scaling factor.
+     *
+     * @param scaling Positive floating point value that indicates how much the image should be enlarged (both
+     * dimensions of the image are enlarged by this value).
+     */
+    toDataUrl(scaling: number): Promise<string>;
+    /**
+     * Original width of this PNG source image in pixels (as if scaling factor 1 was to be used).
+     */
+    getOriginalWidth(): number;
+    /**
+     * Original height of this PNG source image in pixels (as if scaling factor 1 was to be used).
+     */
+    getOriginalHeight(): number;
+}

--- a/types/business/image/PngUtils.d.ts
+++ b/types/business/image/PngUtils.d.ts
@@ -1,0 +1,6 @@
+export default class PngUtils {
+    static htmlElementToPngDataUrl(element: HTMLElement): Promise<string>;
+    static svgElementToPngDataUrl(element: SVGElement, scalingFactor: number): Promise<string>;
+    static svgStringToPngDataUrl(svgString: string, originalWidth: number, originalHeight: number, scalingFactor: number): Promise<string>;
+    static canvasElementToPngDataUrl(element: HTMLCanvasElement): string;
+}

--- a/types/business/image/SvgElementToPngSource.d.ts
+++ b/types/business/image/SvgElementToPngSource.d.ts
@@ -1,0 +1,12 @@
+import PngSource from "@/business/image/PngSource";
+/**
+ * This class implements the PngSource interface and provides some generic methods that convert SVG-data to a
+ * PNG-element.
+ */
+export default class SvgElementToPngSource implements PngSource {
+    private element;
+    constructor(element: SVGElement);
+    toDataUrl(scaling: number): Promise<string>;
+    getOriginalWidth(): number;
+    getOriginalHeight(): number;
+}

--- a/types/business/image/SvgStringToPngSource.d.ts
+++ b/types/business/image/SvgStringToPngSource.d.ts
@@ -1,0 +1,8 @@
+import PngSource from "@/business/image/PngSource";
+export default class SvgStringToPngSource implements PngSource {
+    private svgString;
+    constructor(svgString: string);
+    getOriginalHeight(): number;
+    getOriginalWidth(): number;
+    toDataUrl(scaling: number): Promise<string>;
+}

--- a/types/business/image/SvgUtils.d.ts
+++ b/types/business/image/SvgUtils.d.ts
@@ -1,0 +1,4 @@
+export default class SvgUtils {
+    static elementToSvgDataUrl(element: SVGElement): string;
+    static svgStringToSvgDataUrl(svgString: string): string;
+}

--- a/types/business/ontology/taxonomic/ncbi/NcbiRank.d.ts
+++ b/types/business/ontology/taxonomic/ncbi/NcbiRank.d.ts
@@ -8,10 +8,12 @@ export declare enum NcbiRank {
     Superclass = "superclass",
     Class = "class",
     Subclass = "subclass",
+    Infraclass = "infraclass",
     Superorder = "superorder",
     Order = "order",
     Suborder = "suborder",
     Infraorder = "infraorder",
+    Parvorder = "parvorder",
     Superfamily = "superfamily",
     Family = "family",
     Subfamily = "subfamily",
@@ -23,7 +25,6 @@ export declare enum NcbiRank {
     SpeciesSubgroup = "species subgroup",
     Species = "species",
     Subspecies = "subspecies",
-    Strain = "strain",
     Varietas = "varietas",
     Forma = "forma"
 }


### PR DESCRIPTION
This PR drastically improves the image export functionality for the visualizations provided by Unipept. The following new features are introduced:

* The heatmap can now also be exported
* Resolution of the PNG exports can now be configured (scaling factors from 50% to 1000% should satisfy most users)
* Redesigned the download image modal
* If an image is only available as PNG download, the SVG option will not be present.
* Export resolution cannot be changed for SVG's since these are resolution independent

Old design of the download modal:
![Screenshot 2021-01-08 at 15 50 15](https://user-images.githubusercontent.com/9608686/104028607-371f3300-51c9-11eb-81c4-62930758e0ee.png)

New design of the download modal:
For SVG:
![Screenshot 2021-01-08 at 15 42 37](https://user-images.githubusercontent.com/9608686/104028632-3e464100-51c9-11eb-9533-f1c2e336795d.png)

For PNG:
![Screenshot 2021-01-08 at 15 42 43](https://user-images.githubusercontent.com/9608686/104028640-41d9c800-51c9-11eb-9d0b-35fa17b45be1.png)
