### PR TITLE
Fix and implement fullscreen visualizations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "unipept-web-components",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -33340,9 +33340,9 @@
             }
         },
         "unipept-heatmap": {
-            "version": "2.0.0-beta.6",
-            "resolved": "https://registry.npmjs.org/unipept-heatmap/-/unipept-heatmap-2.0.0-beta.6.tgz",
-            "integrity": "sha512-Ob1x3UUYQWIYaq59F8xKjfMFefRZrN3J585AfSlGjTmGAsFiVnaSff53JQBfMt/pMmAk/nzM34WIKkDTZTQ04Q==",
+            "version": "2.0.0-beta.8",
+            "resolved": "https://registry.npmjs.org/unipept-heatmap/-/unipept-heatmap-2.0.0-beta.8.tgz",
+            "integrity": "sha512-MuJGueIAjF5IMyuZHL729L6bj91q4oJrFS6J80nq+7oDWgQyvfv85vvwrEKIb9TP79EP9Q2IuapJw+GU0U/QLQ==",
             "requires": {
                 "@types/d3": "^5.16.0",
                 "@types/sanitize-html": "^1.27.0",
@@ -34017,9 +34017,9 @@
             }
         },
         "vue-fullscreen": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/vue-fullscreen/-/vue-fullscreen-2.1.5.tgz",
-            "integrity": "sha512-M8wx+OV7uCGOQ/iLi5d2WHbWW9ad9uBPsW50iezV7LDrZ6iuXkDJSCmTaQgnRKJWOOfPsQrgNFME1LKMRrFmgg=="
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/vue-fullscreen/-/vue-fullscreen-2.1.6.tgz",
+            "integrity": "sha512-p2lJYm/RgTHOqARlnljZlOGW/+sQFuSkV20Tje0lfzYoZnqSVR+vC0ytOX5aE0iebMUze63RBNPwpxuxjv6ucA=="
         },
         "vue-hot-reload-api": {
             "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "unipept-web-components",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "private": false,
     "types": "./types",
     "scripts": {
@@ -35,12 +35,12 @@
         "jquery": "^3.4.1",
         "observable-fns": "^0.5.1",
         "shared-memory-datastructures": "0.1.9",
-        "unipept-heatmap": "^2.0.0-beta.6",
+        "unipept-heatmap": "^2.0.0-beta.8",
         "unipept-visualizations": "^1.7.3",
         "uuid": "^3.4.0",
         "vue": "^2.6.11",
         "vue-class-component": "^7.0.2",
-        "vue-fullscreen": "^2.1.5",
+        "vue-fullscreen": "^2.1.6",
         "vue-property-decorator": "^8.1.0",
         "vuetify": "^2.3.8",
         "vuex": "^3.0.1",

--- a/src/components/heatmap/HeatmapVisualization.vue
+++ b/src/components/heatmap/HeatmapVisualization.vue
@@ -1,21 +1,24 @@
 <template>
-    <div style="width: 100%;">
-        <h2 class="ghead">
+    <fullscreen ref="fullscreen">
+        <div style="width: 100%;" class="heatmap-wrapper">
+            <h2 class="ghead">
             <span class="dir">
                 <v-btn x-small fab @click="rotate()" :elevation="0"><v-icon>mdi-format-rotate-90</v-icon></v-btn>
                 <v-btn x-small fab @click="download()" :elevation="0"><v-icon>mdi-download</v-icon></v-btn>
                 <v-btn x-small fab @click="reset()" :elevation="0"><v-icon>mdi-restore</v-icon></v-btn>
+                <v-btn x-small fab @click="enableFullscreen()" :elevation="0"><v-icon>mdi-fullscreen</v-icon></v-btn>
             </span>
-            <span class="dir text">Scroll to zoom, drag to pan.</span>
-        </h2>
-        <div ref="heatmapElement" style="width: 100%" v-once></div>
-        <image-download-modal
-            v-model="downloadModalOpen"
-            base-file-name="unipept_comparative_heatmap"
-            :png-source="pngDataSource"
-            :svg-string="svgString"
-        />
-    </div>
+                <span class="dir text">Scroll to zoom, drag to pan.</span>
+            </h2>
+            <div ref="heatmapElement" style="width: 100%" v-once></div>
+            <image-download-modal
+                v-model="downloadModalOpen"
+                base-file-name="unipept_comparative_heatmap"
+                :png-source="pngDataSource"
+                :svg-string="svgString"
+            />
+        </div>
+    </fullscreen>
 </template>
 
 <script lang="ts">
@@ -36,6 +39,7 @@ import SvgStringToPngSource from "@/business/image/SvgStringToPngSource";
 export default class HeatmapVisualization extends mixins(VisualizationMixin) {
     $refs: {
         heatmapElement: any,
+        fullscreen: any
     }
 
     @Prop({ default: false })
@@ -66,10 +70,6 @@ export default class HeatmapVisualization extends mixins(VisualizationMixin) {
         if (this.heatmap){
             this.heatmap.reset();
         }
-    }
-
-    @Watch("fullScreen") onFullScreenChanged(newFullScreen: boolean, oldFullScreen: boolean) {
-        this.heatmap.setFullScreen(newFullScreen)
     }
 
     @Watch("data")
@@ -129,8 +129,25 @@ export default class HeatmapVisualization extends mixins(VisualizationMixin) {
 
         this.downloadModalOpen = true;
     }
+
+    private async enableFullscreen() {
+        this.$refs.fullscreen.toggle();
+        if (await this.$refs.fullscreen.getState()) {
+            let heatmapElement: HTMLElement = this.$refs.heatmapElement as HTMLElement;
+            this.heatmap.resize(heatmapElement.clientWidth, 600);
+        } else {
+            this.heatmap.resize(window.innerWidth, window.innerHeight);
+        }
+    }
 }
 </script>
 
-<style scoped>
+<style>
+    .heatmap-wrapper {
+        background: white;
+    }
+
+    .fullscreen .heatmap-wrapper {
+        height: 100%;
+    }
 </style>

--- a/src/components/visualizations/SingleDatasetVisualizationsCard.vue
+++ b/src/components/visualizations/SingleDatasetVisualizationsCard.vue
@@ -1,188 +1,147 @@
--<template>
-    <fullscreen ref="fullScreenContainer" @change="fullScreenChange">
-        <v-card style="overflow: hidden; min-height: 100%;" :class="{'full-screen': isFullScreen, 'full-screen-container': true}">
-            <v-tabs :slider-color="isFullScreen ? 'white' : tabsSliderColor" :dark="isDark" :background-color="tabsColor" :fixed-tabs="isFullScreen" v-model="tab">
-                <div v-if="isFullScreen" class="unipept-logo">
-                    <img src="/images/trans_logo.png" alt="logo" width="40" height="40">
-                </div>
-                <v-tab>
-                    Sunburst
-                </v-tab>
-                <v-tab>
-                    Treemap
-                </v-tab>
-                <v-tab>
-                    Treeview
-                </v-tab>
-                <v-tab v-if="!isFullScreen">
-                    Hierarchical Outline
-                </v-tab>
-                <v-tab v-if="!isFullScreen">
-                    Heatmap
-                </v-tab>
-                <v-spacer>
-                </v-spacer>
-                <v-menu v-if="!isFullScreen && this.tab < 3" bottom left :disabled="!this.assay">
-                    <template v-slot:activator="{ on }">
-                        <v-btn text class="align-self-center mr-4" v-on="on">
-                            More
-                            <v-icon right>mdi-menu-down</v-icon>
-                        </v-btn>
-                    </template>
+<template>
+    <v-card style="overflow: hidden; min-height: 100%;" >
+        <v-tabs :slider-color="tabsSliderColor" :dark="isDark" :background-color="tabsColor" v-model="tab">
+            <v-tab>
+                Sunburst
+            </v-tab>
+            <v-tab>
+                Treemap
+            </v-tab>
+            <v-tab>
+                Treeview
+            </v-tab>
+            <v-tab>
+                Hierarchical Outline
+            </v-tab>
+            <v-tab>
+                Heatmap
+            </v-tab>
 
-                    <v-list class="grey lighten-3">
-                        <v-list-item key="enter-full-screen" @click="switchToFullScreen()" >
-                            <v-list-item-title>
-                                <v-icon>
-                                    mdi-fullscreen
-                                </v-icon>
-                                Enter full screen
-                            </v-list-item-title>
-                        </v-list-item>
-                        <v-list-item key="save-as-image" @click="prepareImage()">
-                            <v-list-item-title>
-                                <v-icon>
-                                    mdi-download
-                                </v-icon>
-                                Save as image
-                            </v-list-item-title>
-                        </v-list-item>
-                    </v-list>
-                </v-menu>
-                <div v-if="isFullScreen" class="fullscreen-buttons-container">
-                    <v-btn icon text @click="reset()">
-                        <v-icon color="white">
-                            mdi-restore
-                        </v-icon>
-                    </v-btn>
-                    <v-btn icon text @click="prepareImage()">
-                        <v-icon color="white">
-                            mdi-download
-                        </v-icon>
-                    </v-btn>
-                    <v-btn icon text @click="exitFullScreen()">
-                        <v-icon color="white">
-                            mdi-fullscreen-exit
-                        </v-icon>
-                    </v-btn>
-                </div>
-            </v-tabs>
-            <v-tabs-items v-model="tab">
-                <v-tab-item>
-                    <v-card flat>
-                        <sunburst-visualization
-                            ref="sunburst"
-                            :autoResize="true"
-                            :full-screen="isFullScreen"
-                            v-if="tree"
-                            :tree="tree"
-                            v-on:update-selected-taxon-id="onUpdateSelectedTaxonId">
-                        </sunburst-visualization>
-                        <div v-else-if="this.analysisInProgress" class="mpa-waiting">
-                            <v-progress-circular :size="70" :width="7" color="primary" indeterminate>
-                            </v-progress-circular>
-                        </div>
-                        <div v-else>
-                            <v-card-text>
-                                <div class="placeholder-text">
-                                    {{ placeholderText }}
-                                </div>
-                            </v-card-text>
-                        </div>
-                    </v-card>
-                    <image-download-modal
-                        :base-file-name="imageBaseName"
-                        :svg-string="svgImageData"
-                        :png-source="pngSource"
-                        v-model="downloadImageDialogOpen"
-                    />
-                </v-tab-item>
-                <v-tab-item>
-                    <v-card flat>
-                        <treemap-visualization
-                            ref="treemap"
-                            :full-screen="isFullScreen"
-                            v-if="tree"
-                            :tree="tree"
-                            v-on:update-selected-taxon-id="onUpdateSelectedTaxonId">
-                        </treemap-visualization>
-                        <div v-else-if="this.analysisInProgress" class="mpa-waiting">
-                            <v-progress-circular :size="70" :width="7" color="primary" indeterminate>
-                            </v-progress-circular>
-                        </div>
-                        <div v-else>
-                            <v-card-text>
-                                <div class="placeholder-text">
-                                    {{ placeholderText }}
-                                </div>
-                            </v-card-text>
-                        </div>
-                    </v-card>
-                </v-tab-item>
-                <v-tab-item>
-                    <v-card flat>
-                        <treeview-visualization
-                            ref="treeview"
-                            :autoResize="true"
-                            :height="500"
-                            :full-screen="isFullScreen"
-                            v-if="tree"
-                            :tree="tree"
-                            v-on:update-selected-taxon-id="onUpdateSelectedTaxonId">
-                        </treeview-visualization>
-                        <div v-else-if="this.analysisInProgress" class="mpa-waiting">
-                            <v-progress-circular :size="70" :width="7" color="primary" indeterminate>
-                            </v-progress-circular>
-                        </div>
-                        <div v-else>
-                            <v-card-text>
-                                <div class="placeholder-text">
-                                    {{ placeholderText }}
-                                </div>
-                            </v-card-text>
-                        </div>
-                    </v-card>
-                </v-tab-item>
-                <v-tab-item>
-                    <v-card flat>
+            <v-spacer>
+            </v-spacer>
+
+            <div style="padding-right: 16px;" class="d-flex align-center">
+                <v-btn depressed @click="prepareImage" color="primary">
+                    <v-icon>mdi-download</v-icon>
+                    Save as image
+                </v-btn>
+            </div>
+        </v-tabs>
+        <v-tabs-items v-model="tab">
+            <v-tab-item>
+                <v-card flat>
+                    <sunburst-visualization
+                        ref="sunburst"
+                        :autoResize="true"
+                        :full-screen="isFullScreen"
+                        v-if="tree"
+                        :tree="tree"
+                        v-on:update-selected-taxon-id="onUpdateSelectedTaxonId">
+                    </sunburst-visualization>
+                    <div v-else-if="this.analysisInProgress" class="mpa-waiting">
+                        <v-progress-circular :size="70" :width="7" color="primary" indeterminate>
+                        </v-progress-circular>
+                    </div>
+                    <div v-else>
                         <v-card-text>
-                            <hierarchical-outline-visualization
-                                v-if="tree"
-                                :tree="tree"
-                                :search-configuration="searchConfiguration"
-                                v-on:update-selected-taxon-id="onUpdateSelectedTaxonId">
-                            </hierarchical-outline-visualization>
-                            <div v-else-if="this.analysisInProgress" class="mpa-waiting">
-                                <v-progress-circular :size="70" :width="7" color="primary" indeterminate>
-                                </v-progress-circular>
-                            </div>
-                            <div v-else>
-                                <div class="placeholder-text">
-                                    {{ placeholderText }}
-                                </div>
+                            <div class="placeholder-text">
+                                {{ placeholderText }}
                             </div>
                         </v-card-text>
-                    </v-card>
-                </v-tab-item>
-                <v-tab-item>
-                    <v-card flat>
-                        <heatmap-wizard-single-sample v-if="assay" :assay="assay"></heatmap-wizard-single-sample>
+                    </div>
+                </v-card>
+                <image-download-modal
+                    :base-file-name="imageBaseName"
+                    :svg-string="svgImageData"
+                    :png-source="pngSource"
+                    v-model="downloadImageDialogOpen"
+                />
+            </v-tab-item>
+            <v-tab-item>
+                <v-card flat>
+                    <treemap-visualization
+                        ref="treemap"
+                        :full-screen="isFullScreen"
+                        v-if="tree"
+                        :tree="tree"
+                        v-on:update-selected-taxon-id="onUpdateSelectedTaxonId">
+                    </treemap-visualization>
+                    <div v-else-if="this.analysisInProgress" class="mpa-waiting">
+                        <v-progress-circular :size="70" :width="7" color="primary" indeterminate>
+                        </v-progress-circular>
+                    </div>
+                    <div v-else>
+                        <v-card-text>
+                            <div class="placeholder-text">
+                                {{ placeholderText }}
+                            </div>
+                        </v-card-text>
+                    </div>
+                </v-card>
+            </v-tab-item>
+            <v-tab-item>
+                <v-card flat>
+                    <treeview-visualization
+                        ref="treeview"
+                        :autoResize="true"
+                        :height="500"
+                        :full-screen="isFullScreen"
+                        v-if="tree"
+                        :tree="tree"
+                        v-on:update-selected-taxon-id="onUpdateSelectedTaxonId">
+                    </treeview-visualization>
+                    <div v-else-if="this.analysisInProgress" class="mpa-waiting">
+                        <v-progress-circular :size="70" :width="7" color="primary" indeterminate>
+                        </v-progress-circular>
+                    </div>
+                    <div v-else>
+                        <v-card-text>
+                            <div class="placeholder-text">
+                                {{ placeholderText }}
+                            </div>
+                        </v-card-text>
+                    </div>
+                </v-card>
+            </v-tab-item>
+            <v-tab-item>
+                <v-card flat>
+                    <v-card-text>
+                        <hierarchical-outline-visualization
+                            v-if="tree"
+                            :tree="tree"
+                            :search-configuration="searchConfiguration"
+                            v-on:update-selected-taxon-id="onUpdateSelectedTaxonId">
+                        </hierarchical-outline-visualization>
                         <div v-else-if="this.analysisInProgress" class="mpa-waiting">
                             <v-progress-circular :size="70" :width="7" color="primary" indeterminate>
                             </v-progress-circular>
                         </div>
                         <div v-else>
-                            <v-card-text>
-                                <div class="placeholder-text">
-                                    {{ placeholderText }}
-                                </div>
-                            </v-card-text>
+                            <div class="placeholder-text">
+                                {{ placeholderText }}
+                            </div>
                         </div>
-                    </v-card>
-                </v-tab-item>
-            </v-tabs-items>
-        </v-card>
-    </fullscreen>
+                    </v-card-text>
+                </v-card>
+            </v-tab-item>
+            <v-tab-item>
+                <v-card flat>
+                    <heatmap-wizard-single-sample v-if="assay" :assay="assay"></heatmap-wizard-single-sample>
+                    <div v-else-if="this.analysisInProgress" class="mpa-waiting">
+                        <v-progress-circular :size="70" :width="7" color="primary" indeterminate>
+                        </v-progress-circular>
+                    </div>
+                    <div v-else>
+                        <v-card-text>
+                            <div class="placeholder-text">
+                                {{ placeholderText }}
+                            </div>
+                        </v-card-text>
+                    </div>
+                </v-card>
+            </v-tab-item>
+        </v-tabs-items>
+    </v-card>
 </template>
 
 <script lang="ts">
@@ -201,7 +160,6 @@ import $ from "jquery";
 import CardHeader from "../custom/CardHeader.vue";
 
 //@ts-ignore
-import fullscreen from "vue-fullscreen";
 import { Peptide } from "./../../business/ontology/raw/Peptide";
 import { CountTable } from "./../../business/counts/CountTable";
 import Tree from "./../../business/ontology/taxonomic/Tree";
@@ -228,7 +186,6 @@ import DomElementToPngSource from "@/business/image/DomElementToPngSource";
 })
 export default class SingleDatasetVisualizationsCard extends Vue {
     $refs!: {
-        fullScreenContainer: fullscreen,
         sunburst: SunburstVisualization,
         treeview: TreeviewVisualization,
         treemap: TreemapVisualization,
@@ -274,34 +231,7 @@ export default class SingleDatasetVisualizationsCard extends Vue {
         return this.assay?.getSearchConfiguration();
     }
 
-    private switchToFullScreen() {
-        // @ts-ignore
-        if (!this.isFullScreen && window.fullScreenApi.supportsFullScreen) {
-            this.isFullScreen = true;
-            this.$refs.fullScreenContainer.enter();
-            // @ts-ignore
-            AnalyticsUtil.logToGoogle("Multi Peptide", "Full Screen", this.tabs[this.tab]);
-            $(".tip").appendTo(".full-screen-container");
-        }
-    }
-
-    private exitFullScreen() {
-        this.isFullScreen = false;
-        this.$refs.fullScreenContainer.exit();
-        $(".tip").appendTo("body");
-    }
-
-    private fullScreenChange(state: boolean) {
-        if (!state) {
-            this.exitFullScreen();
-        } else {
-            this.switchToFullScreen();
-        }
-    }
-
     private async prepareImage() {
-        this.exitFullScreen();
-
         AnalyticsUtil.logToGoogle("Multi Peptide", "Save Image", this.tabs[this.tab]);
         if (this.tabs[this.tab] === "Sunburst") {
             d3.selectAll(".toHide").attr("class", "arc hidden");

--- a/src/components/visualizations/SunburstVisualization.vue
+++ b/src/components/visualizations/SunburstVisualization.vue
@@ -1,47 +1,57 @@
 <template>
-    <div id="sunburstWrapper" ref="sunburstWrapper" v-if="active">
-        <h2 class="ghead">
-            <span class="dir">
-                <v-btn x-small fab @click="reset()" :elevation="0"><v-icon>mdi-restore</v-icon></v-btn>
-            </span>
-            <span class="dir">
-                <v-menu>
-                    <template v-slot:activator="{ on }">
-                        <v-btn fab x-small v-on="on" :elevation="0">
-                            <v-icon>mdi-cog-outline</v-icon>
-                        </v-btn>
-                    </template>
-                    <v-list>
-                        <v-list-item>
-                            <v-list-item-action>
-                                <v-checkbox v-model="isFixedColors" color="primary"></v-checkbox>
-                            </v-list-item-action>
+    <fullscreen ref="fullscreen">
+        <div id="sunburstWrapper" ref="sunburstWrapper" v-if="active">
+            <h2 class="ghead">
+                <span class="dir">
+                    <v-btn x-small fab @click="enableFullscreen()" :elevation="0">
+                        <v-icon>mdi-fullscreen</v-icon>
+                    </v-btn>
+                </span>
+                <span class="dir">
+                    <v-btn x-small fab @click="reset()" :elevation="0">
+                        <v-icon>mdi-restore</v-icon>
+                    </v-btn>
+                </span>
+                <span class="dir">
+                    <v-menu>
+                        <template v-slot:activator="{ on }">
+                            <v-btn fab x-small v-on="on" :elevation="0">
+                                <v-icon>mdi-cog-outline</v-icon>
+                            </v-btn>
+                        </template>
+                        <v-list>
+                            <v-list-item>
+                                <v-list-item-action>
+                                    <v-checkbox v-model="isFixedColors" color="primary"></v-checkbox>
+                                </v-list-item-action>
 
-                            <v-list-item-content>
-                                <v-list-item-title>Use fixed colors</v-list-item-title>
-                            </v-list-item-content>
-                        </v-list-item>
-                    </v-list>
-                </v-menu>
-            </span>
-            <span class="dir text">Click a slice to zoom in and the center node to zoom out</span>
-        </h2>
-        <div v-once ref="visualization"></div>
-    </div>
-    <v-container fluid v-else class="error-container mt-2 d-flex align-center">
-        <div class="error-container">
-            <v-icon x-large>
-                mdi-alert-circle-outline
-            </v-icon>
-            <p>
-                You're trying to visualise a very large sample. This will work in most cases, but it could take
-                some time to render. Are you sure you want to <a @click="showVisualization()">continue</a>?
-            </p>
+                                <v-list-item-content>
+                                    <v-list-item-title>Use fixed colors</v-list-item-title>
+                                </v-list-item-content>
+                            </v-list-item>
+                        </v-list>
+                    </v-menu>
+                </span>
+                <span class="dir text">Click a slice to zoom in and the center node to zoom out</span>
+            </h2>
+            <div v-once ref="visualization"></div>
         </div>
-    </v-container>
+        <v-container fluid v-else class="error-container mt-2 d-flex align-center">
+            <div class="error-container">
+                <v-icon x-large>
+                    mdi-alert-circle-outline
+                </v-icon>
+                <p>
+                    You're trying to visualise a very large sample. This will work in most cases, but it could take
+                    some time to render. Are you sure you want to <a @click="showVisualization()">continue</a>?
+                </p>
+            </div>
+        </v-container>
+    </fullscreen>
 </template>
 
 <script lang="ts">
+import fullscreen from "vue-fullscreen";
 import Vue from "vue";
 import Component, { mixins } from "vue-class-component";
 import { Prop, Watch } from "vue-property-decorator";
@@ -51,11 +61,15 @@ import Tree from "./../../business/ontology/taxonomic/Tree";
 
 @Component
 export default class SunburstVisualization extends mixins(VisualizationMixin) {
+    $refs!: {
+        sunburstWrapper: any,
+        fullscreen: any,
+        visualization: any
+    }
+
     // Make field non-reactive by not setting it here, but only after created has been called for the first time.
     sunburst!: any;
 
-    @Prop({ default: false })
-    private fullScreen: false;
     @Prop({ required: true })
     private tree: Tree;
     @Prop({ required: false, default: false })
@@ -86,11 +100,6 @@ export default class SunburstVisualization extends mixins(VisualizationMixin) {
     @Watch("tree")
     private async onTreeChanged() {
         await this.initTree();
-    }
-
-    @Watch("fullScreen")
-    private onFullScreenChanged(newFullScreen: boolean, oldFullScreen: boolean) {
-        this.sunburst.setFullScreen(newFullScreen)
     }
 
     @Watch("isFixedColors")
@@ -139,6 +148,10 @@ export default class SunburstVisualization extends mixins(VisualizationMixin) {
             svgEl.setAttribute("width", "100%")
         }
     }
+
+    private enableFullscreen() {
+        this.$refs.fullscreen.toggle();
+    }
 }
 </script>
 
@@ -170,7 +183,15 @@ export default class SunburstVisualization extends mixins(VisualizationMixin) {
         text-align: center;
     }
 
+    #sunburstWrapper {
+        background: white;
+    }
+
     #sunburstWrapper > .unipept-sunburst > svg {
         max-height: 800px;
+    }
+
+    .fullscreen #sunburstWrapper > .unipept-sunburst > svg {
+        max-height: calc(100% - 43px);
     }
 </style>

--- a/src/components/visualizations/TreemapVisualization.vue
+++ b/src/components/visualizations/TreemapVisualization.vue
@@ -1,24 +1,31 @@
 <template>
-    <div id="treemapWrapper" ref="treemapWrapper" style="height: 100%;" v-if="active">
-        <h2 class="ghead">
-            <span class="dir">
-                <v-btn x-small fab @click="reset()" :elevation="0"><v-icon>mdi-restore</v-icon></v-btn>
-            </span>
-            <span class="dir text">Click a square to zoom in and right click to zoom out</span>
-        </h2>
-        <div v-once ref="visualization"></div>
-    </div>
-    <v-container fluid v-else class="error-container mt-2 d-flex align-center">
-        <div class="error-container">
-            <v-icon x-large>
-                mdi-alert-circle-outline
-            </v-icon>
-            <p>
-                You're trying to visualise a very large sample. This will work in most cases, but it could take
-                some time to render. Are you sure you want to <a @click="showVisualization()">continue</a>?
-            </p>
+    <fullscreen ref="fullscreen">
+        <div id="treemapWrapper" ref="treemapWrapper" style="height: 100%;" v-if="active">
+            <h2 class="ghead">
+                <span class="dir">
+                    <v-btn x-small fab @click="enableFullscreen()" :elevation="0">
+                        <v-icon>mdi-fullscreen</v-icon>
+                    </v-btn>
+                </span>
+                <span class="dir">
+                    <v-btn x-small fab @click="reset()" :elevation="0"><v-icon>mdi-restore</v-icon></v-btn>
+                </span>
+                <span class="dir text">Click a square to zoom in and right click to zoom out</span>
+            </h2>
+            <div v-once ref="visualization"></div>
         </div>
-    </v-container>
+        <v-container fluid v-else class="error-container mt-2 d-flex align-center">
+            <div class="error-container">
+                <v-icon x-large>
+                    mdi-alert-circle-outline
+                </v-icon>
+                <p>
+                    You're trying to visualise a very large sample. This will work in most cases, but it could take
+                    some time to render. Are you sure you want to <a @click="showVisualization()">continue</a>?
+                </p>
+            </div>
+        </v-container>
+    </fullscreen>
 </template>
 
 <script lang="ts">
@@ -32,6 +39,11 @@ import { NcbiRank } from "./../../business/ontology/taxonomic/ncbi/NcbiRank";
 
 @Component
 export default class TreemapVisualization extends mixins(VisualizationMixin) {
+    $refs!: {
+        fullscreen: any,
+        treemapWrapper: any
+    }
+
     // Make field non-reactive by not setting the value here, but only after created() has been fired.
     treemap!: any;
 
@@ -99,6 +111,10 @@ export default class TreemapVisualization extends mixins(VisualizationMixin) {
             rerootCallback: d => this.search(d.id, d.name, 1000)
         });
     }
+
+    private enableFullscreen() {
+        this.$refs.fullscreen.toggle();
+    }
 }
 </script>
 
@@ -112,4 +128,10 @@ export default class TreemapVisualization extends mixins(VisualizationMixin) {
         flex-direction: column;
         text-align: center;
     }
+
+    #treemapWrapper {
+        background: white;
+    }
+
+
 </style>

--- a/src/components/visualizations/Treeview.vue
+++ b/src/components/visualizations/Treeview.vue
@@ -158,7 +158,15 @@ export default class Treeview extends Vue {
     }
 
    .treeview-container svg {
-        width: 100% !important;
-        max-height: 600px !important;
+        width: 100%;
+        max-height: 600px;
     }
+
+   .fullscreen .treeview-container svg {
+       max-height: 100%;
+   }
+
+   .fullscreen .treeview-container {
+       height: 100%;
+   }
 </style>

--- a/src/components/visualizations/TreeviewVisualization.vue
+++ b/src/components/visualizations/TreeviewVisualization.vue
@@ -1,26 +1,33 @@
 <template>
-    <div id="treeviewWrapper" ref="treeviewWrapper" style="height: 100%;">
-        <h2 class="ghead">
-            <span class="dir">
-                <v-btn x-small fab @click="reset()" :elevation="0"><v-icon>mdi-restore</v-icon></v-btn>
-            </span>
-            <span class="dir text">
-                Scroll to zoom, drag to pan, click a node to expand, right click a node to set as root
-            </span>
-        </h2>
-        <treeview
-            ref="treeview"
-            :data="data"
-            :autoResize="autoResize"
-            :width="width"
-            :height="height"
-            :enableAutoExpand="true"
-            :tooltip="tooltipFunction"
-            :colors="colors"
-            :rerootCallback="rerootCallback"
-        >
-        </treeview>
-    </div>
+    <fullscreen ref="fullscreen">
+        <div id="treeviewWrapper" ref="treeviewWrapper" style="height: 100%;">
+            <h2 class="ghead">
+                <span class="dir">
+                    <v-btn x-small fab @click="enableFullscreen()" :elevation="0">
+                        <v-icon>mdi-fullscreen</v-icon>
+                    </v-btn>
+                </span>
+                <span class="dir">
+                    <v-btn x-small fab @click="reset()" :elevation="0"><v-icon>mdi-restore</v-icon></v-btn>
+                </span>
+                <span class="dir text">
+                    Scroll to zoom, drag to pan, click a node to expand, right click a node to set as root
+                </span>
+            </h2>
+            <treeview
+                ref="treeview"
+                :data="data"
+                :autoResize="autoResize"
+                :width="width"
+                :height="height"
+                :enableAutoExpand="true"
+                :tooltip="tooltipFunction"
+                :colors="colors"
+                :rerootCallback="rerootCallback"
+            >
+            </treeview>
+        </div>
+    </fullscreen>
 </template>
 
 <script lang="ts">
@@ -42,7 +49,8 @@ import TreeNode from "./../../business/ontology/taxonomic/TreeNode";
 export default class TreeviewVisualization extends mixins(VisualizationMixin) {
     $refs: {
         treeview: Treeview
-        treeviewWrapper: Element
+        treeviewWrapper: Element,
+        fullscreen: any
     }
 
     @Prop({ required: true })
@@ -99,14 +107,26 @@ export default class TreeviewVisualization extends mixins(VisualizationMixin) {
             this.data = this.tree.getRoot();
         }
     }
+
+    private enableFullscreen() {
+        this.$refs.fullscreen.toggle();
+    }
 }
 </script>
 
 <style lang="less">
     @import './../../assets/style/visualizations.css.less';
 
-    .treeviewWrapper svg {
-        width: 100% !important;
-        max-height: 600px !important;
+    #treeviewWrapper {
+        background: white;
+    }
+
+    #treeviewWrapper svg {
+        width: 100%;
+        max-height: 600px;
+    }
+
+    .fullscreen #treeviewWrapper svg {
+        max-height: 100%;
     }
 </style>

--- a/src/typings/vue-fullscreen.d.ts
+++ b/src/typings/vue-fullscreen.d.ts
@@ -1,0 +1,7 @@
+declare module "vue-fullscreen" {
+    import Vue, { PluginFunction, PluginObject } from "vue";
+
+    const install: PluginFunction<any>;
+
+    export default install;
+}


### PR DESCRIPTION
This PR re-introduces the fullscreen mode for all of the different visualization types (including the heatmap). This mode was broken for a long time due to some issues with resizing the visualizations, but should be fixed for now with this PR.