### PR TITLE
Fix save button positioning in TreeView in AmountTable

### DIFF
--- a/src/components/tables/AmountTable.vue
+++ b/src/components/tables/AmountTable.vue
@@ -365,4 +365,8 @@ export default class AmountTable extends Vue {
 
 <style lang="less" scoped>
     @import './../../assets/style/amount-table.css.less';
+
+    td.item-treeview {
+        padding: 0 !important;
+    }
 </style>


### PR DESCRIPTION
Positioning of the "save as image" button in the TreeView visualization for the AmountTable was incorrect. This PR introduces a fix by removing redundant padding.

Before: 
![image](https://user-images.githubusercontent.com/9608686/104319720-8de67e80-54e1-11eb-9124-65f00f1c0c1a.png)

After:
![image](https://user-images.githubusercontent.com/9608686/104319811-b4a4b500-54e1-11eb-892c-1ccb14886636.png)
