### PR TITLE
Add trust about filter to AssayData

### DIFF
--- a/src/components/analysis/functional/FunctionalSummaryCard.vue
+++ b/src/components/analysis/functional/FunctionalSummaryCard.vue
@@ -82,26 +82,7 @@
                     </v-list>
                 </v-menu>
             </v-tabs>
-            <v-alert
-                v-if="this.filteredNcbiId !== 1"
-                dense
-                colored-border
-                id="filtered-taxon-information">
-                <v-row dense align="center">
-                    <v-col class="grow">
-                        <b>
-                            Filtered results
-                        </b>
-                        : These results are limited to the {{ this.filteredCountTable.totalCount }} peptides specific to
-                        <b>
-                            {{ this.filteredNcbiTaxon.name }} ({{this.filteredNcbiTaxon.rank}})
-                        </b>.
-                    </v-col>
-                    <v-col class="shrink">
-                        <v-btn @click="resetFilter">Reset filter</v-btn>
-                    </v-col>
-                </v-row>
-            </v-alert>
+
             <v-tabs-items v-model="currentTab">
                 <v-tab-item>
                     <multi-go-summary-card
@@ -268,10 +249,6 @@ export default class FunctionalSummaryCard extends Vue {
     private disableRelativeCounts(): void {
         this.showPercentage = false;
         this.selectedSortTypeName = "Peptides";
-    }
-
-    private resetFilter(): void {
-        this.$store.dispatch("filterAssayByTaxon", [this.assay, 1]);
     }
 }
 </script>

--- a/src/components/analysis/statistics/ExportResultsButton.vue
+++ b/src/components/analysis/statistics/ExportResultsButton.vue
@@ -1,32 +1,34 @@
 <template>
-    <tooltip message="Download a CSV-file with the results of this analysis.">
-        <v-menu offset-y bottom left origin="top right">
-            <template v-slot:activator="{ on }">
-                <v-btn min-width="187" :disabled="analysisLoading || exportLoading" v-on="on" color="default">
-                    <div v-if="!exportLoading">
-                        <v-icon>
-                            mdi-download
-                        </v-icon>
-                        {{ buttonText }}
-                        <v-icon>mdi-menu-down</v-icon>
-                    </div>
-                    <v-progress-circular v-else indeterminate color="black" :size="20">
-                    </v-progress-circular>
-                </v-btn>
-            </template>
-            <v-list>
-                <v-list-item @click="downloadCsv()">
-                    <v-list-item-title>Comma-separated (international)</v-list-item-title>
-                </v-list-item>
-                <v-list-item @click="downloadCsv(';', ',')">
-                    <v-list-item-title>Semi-colon-separated (Europe)</v-list-item-title>
-                </v-list-item>
-                <v-list-item @click="downloadCsv('\t', ';')">
-                    <v-list-item-title>Tab-separated</v-list-item-title>
-                </v-list-item>
-            </v-list>
-        </v-menu>
-    </tooltip>
+    <div>
+        <tooltip message="Download a CSV-file with the results of this analysis.">
+            <v-menu offset-y bottom left origin="top right">
+                <template v-slot:activator="{ on }">
+                    <v-btn min-width="187" :disabled="analysisLoading || exportLoading" v-on="on" color="default">
+                        <div v-if="!exportLoading">
+                            <v-icon>
+                                mdi-download
+                            </v-icon>
+                            {{ buttonText }}
+                            <v-icon>mdi-menu-down</v-icon>
+                        </div>
+                        <v-progress-circular v-else indeterminate color="black" :size="20">
+                        </v-progress-circular>
+                    </v-btn>
+                </template>
+                <v-list>
+                    <v-list-item @click="downloadCsv()">
+                        <v-list-item-title>Comma-separated (international)</v-list-item-title>
+                    </v-list-item>
+                    <v-list-item @click="downloadCsv(';', ',')">
+                        <v-list-item-title>Semi-colon-separated (Europe)</v-list-item-title>
+                    </v-list-item>
+                    <v-list-item @click="downloadCsv('\t', ';')">
+                        <v-list-item-title>Tab-separated</v-list-item-title>
+                    </v-list-item>
+                </v-list>
+            </v-menu>
+        </tooltip>
+    </div>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
Until now only the peptide trust information for the unfiltered version of a count table was kept. This PR now also adds trust information to a filtered version of the AssayData.