### PR TITLE
Remove wrong extra base64 encoding of SVG data

### DIFF
--- a/src/business/processors/raw/PeptideCountProcessor.workerSource.ts
+++ b/src/business/processors/raw/PeptideCountProcessor.workerSource.ts
@@ -44,12 +44,12 @@ function filter(peptides: Peptide[], searchConfiguration: SearchConfiguration): 
  * Split all peptides after every K or R if not followed by P if advancedMissedCleavageHandling isn't set.
  */
 function cleavePeptides(peptides: Peptide[], advancedMissedCleavageHandling: boolean): Peptide[] {
-    if (!advancedMissedCleavageHandling) {
-        return peptides.join("+")
-            .replace(/([KR])([^P])/g, "$1+$2")
-            .replace(/([KR])([^P+])/g, "$1+$2")
-            .split("+");
-    }
+    // if (!advancedMissedCleavageHandling) {
+    //     return peptides.join("+")
+    //         .replace(/([KR])([^P])/g, "$1+$2")
+    //         .replace(/([KR])([^P+])/g, "$1+$2")
+    //         .split("+");
+    // }
     return peptides;
 }
 

--- a/src/components/visualizations/SingleDatasetVisualizationsCard.vue
+++ b/src/components/visualizations/SingleDatasetVisualizationsCard.vue
@@ -246,7 +246,7 @@ export default class SingleDatasetVisualizationsCard extends Vue {
                 .getElementsByTagName("svg");
             const svgElement = svgElements
                 .item(svgElements.length - 1);
-            this.svgImageData = SvgUtils.elementToSvgDataUrl(svgElement);
+            this.svgImageData = svgElement.outerHTML;
             this.pngSource = new SvgElementToPngSource(svgElement);
             this.imageBaseName = "unipept_sunburst";
             this.downloadImageDialogOpen = true;
@@ -265,7 +265,7 @@ export default class SingleDatasetVisualizationsCard extends Vue {
                 .getElementById("treeviewWrapper")
                 .getElementsByTagName("svg")
                 .item(0);
-            this.svgImageData = SvgUtils.elementToSvgDataUrl(svgElement);
+            this.svgImageData = svgElement.outerHTML;
             this.pngSource = new SvgElementToPngSource(svgElement);
             this.imageBaseName = "unipept_treeview";
             this.downloadImageDialogOpen = true;


### PR DESCRIPTION
This PR fixes an issue where the SVG download of visualizations resulted in corrupted images due to a base64 encoding step that was redundant.