### PR TITLE
Re-enable code that cleaves peptides if MCH is disabled

### DIFF
--- a/src/logic/processing/peptide/PeptideCountTableProcessor.workerSource.ts
+++ b/src/logic/processing/peptide/PeptideCountTableProcessor.workerSource.ts
@@ -11,13 +11,13 @@ import Peptide from "../../../logic/ontology/peptide/Peptide";
  */
  export default async function compute(
     [
-        peptides, 
-        enableMissingCleavageHandling, 
-        filterDuplicates, 
+        peptides,
+        enableMissingCleavageHandling,
+        filterDuplicates,
         equateIl
     ]: [
-        Peptide[], 
-        boolean, 
+        Peptide[],
+        boolean,
         boolean,
         boolean
     ]
@@ -53,12 +53,12 @@ function filter(peptides: Peptide[], enableMissingCleavageHandling: boolean, equ
  * Split all peptides after every K or R if not followed by P if advancedMissedCleavageHandling isn't set.
  */
 function cleavePeptides(peptides: Peptide[], advancedMissedCleavageHandling: boolean): Peptide[] {
-    // if (!advancedMissedCleavageHandling) {
-    //     return peptides.join("+")
-    //         .replace(/([KR])([^P])/g, "$1+$2")
-    //         .replace(/([KR])([^P+])/g, "$1+$2")
-    //         .split("+");
-    // }
+    if (!advancedMissedCleavageHandling) {
+        return peptides.join("+")
+            .replace(/([KR])([^P])/g, "$1+$2")
+            .replace(/([KR])([^P+])/g, "$1+$2")
+            .split("+");
+    }
     return peptides;
 }
 


### PR DESCRIPTION
If an analysis is performed with the "missed cleavage handling" setting disabled, the peptides should be cleaved by the application. For some reason, this code was disabled and this was thus no longer happening. This PR re-enables this piece of code and fixes the issue.