### PR TITLE
Remove updating I to L

### DIFF
--- a/src/logic/communication/peptide/Pept2DataCommunicator.ts
+++ b/src/logic/communication/peptide/Pept2DataCommunicator.ts
@@ -54,7 +54,7 @@ export default class Pept2DataCommunicator {
                 try {
                     const response = await NetworkUtils.postJson(this.apiBaseUrl + "/mpa/pept2data", requestData);
 
-                    for(const peptide of response.peptides) {
+                    for (const peptide of response.peptides) {
                         result.set(peptide.sequence, PeptideData.createFromPeptideDataResponse(peptide));
                     }
 
@@ -72,7 +72,7 @@ export default class Pept2DataCommunicator {
 
         try {
             // Perform the actual requests in parallel. (await cannot be removed!!)
-            await parallelLimit(requests, this.parallelRequests);  
+            await parallelLimit(requests, this.parallelRequests);
 
             const trustProcessor = new PeptideTrustProcessor();
             const trust = trustProcessor.getPeptideTrust(countTable, result);

--- a/src/logic/processing/peptide/PeptideCountTableProcessor.workerSource.ts
+++ b/src/logic/processing/peptide/PeptideCountTableProcessor.workerSource.ts
@@ -45,8 +45,7 @@ import Peptide from "../../../logic/ontology/peptide/Peptide";
 
 function filter(peptides: Peptide[], enableMissingCleavageHandling: boolean, equateIl: boolean): Peptide[] {
     let out = cleavePeptides(peptides, enableMissingCleavageHandling);
-    out = filterShortPeptides(out);
-    return equateIL(out, equateIl);
+    return filterShortPeptides(out);
 }
 
 /**
@@ -67,14 +66,4 @@ function cleavePeptides(peptides: Peptide[], advancedMissedCleavageHandling: boo
  */
 function filterShortPeptides(peptides: Peptide[]): Peptide[] {
     return peptides.filter(p => p.length >= 5);
-}
-
-/**
- * Replaces every I with an L if equateIL is set to true.
- */
-function equateIL(peptides: Peptide[], equateIL: boolean): Peptide[] {
-    if (equateIL) {
-        return peptides.map(p => p.replace(/I/g, "L"));
-    }
-    return peptides;
 }


### PR DESCRIPTION
This PR removes the translation of I to L by the web components. This change is required to make sure that the frontend of Unipept can still keep track of which peptides belong to which results (and properly export them to CSV when required).

See also: https://github.com/unipept/unipept-api/pull/19