### PR TITLE
Replace 'test' text in title of heatmap wizard card

### DIFF
--- a/src/components/visualizations/heatmap/multi/DataSourceMulti.vue
+++ b/src/components/visualizations/heatmap/multi/DataSourceMulti.vue
@@ -3,7 +3,7 @@
         <v-select
             v-model="selectedDataSource"
             :items="dataSources"
-            label="test"
+            label="Feature type"
             class="flex-grow-0"
         />
 

--- a/src/components/visualizations/heatmap/single/DataSourceSingle.vue
+++ b/src/components/visualizations/heatmap/single/DataSourceSingle.vue
@@ -3,7 +3,7 @@
         <v-select
             v-model="selectedDataSource"
             :items="dataSources"
-            label="test"
+            label="Feature type"
             class="flex-grow-0"
         />
 


### PR DESCRIPTION
There was still the word "test" instead of "data source" in the selection control for the data that should be used on each of the axes of the heatmap. After second thought, I did update this to "feature type" instead of "data source" since that does sound a bit like an ambiguous term.